### PR TITLE
Fix for #12

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazons3/auth/AmazonS3AuthConnector.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/auth/AmazonS3AuthConnector.java
@@ -172,10 +172,10 @@ public class AmazonS3AuthConnector extends AbstractConnector {
             stringToSign.append(AmazonS3Constants.NEW_LINE);
             stringToSign.append(bytesToHex(hash(messageContext, canonicalRequest.toString())).toLowerCase());
 
-            if (StringUtils.isNotEmpty(messageContext.getProperty(AmazonS3Constants.SECRET_ACCESS_KEY).toString()) &&
-                    StringUtils.isNotEmpty(messageContext.getProperty(AmazonS3Constants.REGION).toString()) &&
-                    StringUtils.isNotEmpty(messageContext.getProperty(AmazonS3Constants.SERVICE).toString()) &&
-                    StringUtils.isNotEmpty(shortDate)) {
+            if ((messageContext.getProperty(AmazonS3Constants.SECRET_ACCESS_KEY) != null) &&
+                    (messageContext.getProperty(AmazonS3Constants.REGION) != null) &&
+                    (messageContext.getProperty(AmazonS3Constants.SERVICE) != null) &&
+                    (shortDate) != null) {
                 final byte[] signingKey =
                         getSignatureKey(messageContext,
                                 messageContext.getProperty(AmazonS3Constants.SECRET_ACCESS_KEY).toString(),
@@ -207,12 +207,14 @@ public class AmazonS3AuthConnector extends AbstractConnector {
 
                 // Adds authorization header to message context
                 messageContext.setProperty(AmazonS3Constants.AUTH_CODE, authHeader.toString());
-            } else{
-                if(log.isDebugEnabled()){
-                    log.debug("uri.var.secretAccessKey or uri.var.region or uri.var.service or shortDate may be null" +
+            } else {
+                if (log.isDebugEnabled()) {
+                    log.debug("secretAccessKey or region or service or shortDate may be null" +
                             "Hence couldn't generate signingKey");
                 }
-                handleException(AmazonS3Constants.CONNECTOR_ERROR, messageContext);
+                handleException(AmazonS3Constants.CONNECTOR_ERROR + " secretAccessKey or region or service or " +
+                        "shortDate may be null" +
+                        "Hence couldn't generate signingKey." , messageContext);
             }
         } catch (InvalidKeyException exc) {
             storeErrorResponseStatus(messageContext, exc, AmazonS3Constants.INVALID_KEY_ERROR_CODE);

--- a/src/main/resources/buckets/headBucket.xml
+++ b/src/main/resources/buckets/headBucket.xml
@@ -20,6 +20,12 @@
     <sequence>
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
         <payloadFactory media-type="xml">
             <format>

--- a/src/main/resources/buckets/headBucket.xml
+++ b/src/main/resources/buckets/headBucket.xml
@@ -20,7 +20,6 @@
     <sequence>
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
-        <!--<property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>-->
         <property name="uri.var.uriRemainder" value='/'/>
         <payloadFactory media-type="xml">
             <format>

--- a/src/main/resources/buckets/headBucket.xml
+++ b/src/main/resources/buckets/headBucket.xml
@@ -20,13 +20,8 @@
     <sequence>
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
-        <script language="js">
-            <![CDATA[
-            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
-        ]]>
-        </script>
-        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+        <!--<property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>-->
+        <property name="uri.var.uriRemainder" value='/'/>
         <payloadFactory media-type="xml">
             <format>
                 <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">

--- a/src/main/resources/objects/abortMultipartUpload.xml
+++ b/src/main/resources/objects/abortMultipartUpload.xml
@@ -37,12 +37,12 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-            mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
         <property name="uri.var.uriRemainder"
-                  expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+                  expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <class name="org.wso2.carbon.connector.amazons3.auth.AmazonS3AuthConnector"/>
         <!-- Properties Assigned in AmazonS3AuthConnector -->
         <filter xpath="string($ctx:date) and $ctx:date != ''">
@@ -68,7 +68,8 @@
         </filter>
         <call>
             <endpoint>
-                <http method="delete" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}?uploadId={+uri.var.uploadId}"/>
+                <http method="delete"
+                      uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}?uploadId={+uri.var.uploadId}"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/abortMultipartUpload.xml
+++ b/src/main/resources/objects/abortMultipartUpload.xml
@@ -34,6 +34,12 @@
         <property name="uri.var.contentEncoding" expression="$func:contentEncoding"/>
         <property name="uri.var.expires" expression="$func:expires"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+            mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
         <property name="uri.var.uriRemainder"
                   expression="fn:concat('/',$ctx:uri.var.objectName)"/>

--- a/src/main/resources/objects/completeMultipartUpload.xml
+++ b/src/main/resources/objects/completeMultipartUpload.xml
@@ -38,13 +38,13 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
         <property name="uri.var.partDetails" expression="$func:partDetails"/>
         <property name="uri.var.uriRemainder"
-                  expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+                  expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <filter xpath="string($ctx:uri.var.addCharset)='true'">
             <then>
                 <property name="uri.var.contentType"
@@ -84,7 +84,8 @@
         </filter>
         <call>
             <endpoint>
-                <http method="post" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}?uploadId={+uri.var.uploadId}"/>
+                <http method="post"
+                      uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}?uploadId={+uri.var.uploadId}"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/completeMultipartUpload.xml
+++ b/src/main/resources/objects/completeMultipartUpload.xml
@@ -35,6 +35,12 @@
         <property name="uri.var.contentEncoding" expression="$func:contentEncoding"/>
         <property name="uri.var.expires" expression="$func:expires"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
         <property name="uri.var.partDetails" expression="$func:partDetails"/>
         <property name="uri.var.uriRemainder"

--- a/src/main/resources/objects/createObject.xml
+++ b/src/main/resources/objects/createObject.xml
@@ -24,6 +24,12 @@
         <property name="uri.var.uriRemainder" value=""/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <filter xpath="string($ctx:uri.var.addCharset)='true'">
             <then>
                 <property name="uri.var.contentType"

--- a/src/main/resources/objects/createObject.xml
+++ b/src/main/resources/objects/createObject.xml
@@ -27,7 +27,7 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <filter xpath="string($ctx:uri.var.addCharset)='true'">
@@ -38,8 +38,8 @@
         </filter>
         <script language="js">
             <![CDATA[
-            var objectName=mc.getProperty('uri.var.objectName');
-            mc.setProperty('uri.var.uriRemainder', '/'+objectName);
+            var encodedObjectName=mc.getProperty('uri.var.encodedObjectName');
+            mc.setProperty('uri.var.uriRemainder', '/'+encodedObjectName);
         ]]>
         </script>
         <class name="org.wso2.carbon.connector.amazons3.auth.AmazonS3AuthConnector"/>
@@ -74,7 +74,7 @@
                 <call blocking="true">
                     <endpoint>
                         <http method="put"
-                              uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}"/>
+                              uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}"/>
                     </endpoint>
                 </call>
             </then>
@@ -82,7 +82,7 @@
                 <call>
                     <endpoint>
                         <http method="put"
-                              uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}"/>
+                              uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}"/>
                     </endpoint>
                 </call>
             </else>

--- a/src/main/resources/objects/createObjectACL.xml
+++ b/src/main/resources/objects/createObjectACL.xml
@@ -28,7 +28,7 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
@@ -36,7 +36,7 @@
         <property name="uri.var.ownerDisplayName" expression="$func:ownerDisplayName"/>
         <property name="uri.var.accessControlList" expression="$func:accessControlList"/>
         <property name="uri.var.versionId" expression="$func:versionId"/>
-        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <property name="uri.var.queryString" value="acl"/>
         <payloadFactory media-type="xml">
             <format>
@@ -91,7 +91,7 @@
         </filter>
         <call>
             <endpoint>
-                <http method="put" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}?acl"/>
+                <http method="put" uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}?acl"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/createObjectACL.xml
+++ b/src/main/resources/objects/createObjectACL.xml
@@ -25,6 +25,12 @@
     <sequence>
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.ownerId" expression="$func:ownerId"/>
         <property name="uri.var.ownerDisplayName" expression="$func:ownerDisplayName"/>

--- a/src/main/resources/objects/createObjectCopy.xml
+++ b/src/main/resources/objects/createObjectCopy.xml
@@ -22,6 +22,12 @@
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.destinationObject" expression="$func:destinationObject"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.destinationObject'));
+                mc.setProperty('uri.var.destinationObject' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.destinationObject)"/>
         <filter xpath="string($ctx:uri.var.addCharset)='true'">
             <then>

--- a/src/main/resources/objects/createObjectCopy.xml
+++ b/src/main/resources/objects/createObjectCopy.xml
@@ -25,10 +25,10 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.destinationObject'));
-                mc.setProperty('uri.var.destinationObject' , encodedObjectName);
+                mc.setProperty('uri.var.encodedDestinationObject' , encodedObjectName);
         ]]>
         </script>
-        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.destinationObject)"/>
+        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.encodedDestinationObject)"/>
         <filter xpath="string($ctx:uri.var.addCharset)='true'">
             <then>
                 <property name="uri.var.contentType"
@@ -90,7 +90,7 @@
         </filter>
         <call>
             <endpoint>
-                <http method="put" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}"/>
+                <http method="put" uri-template="{uri.var.bucketUrl}/{+uri.var.destinationObject}"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/deleteObject.xml
+++ b/src/main/resources/objects/deleteObject.xml
@@ -26,13 +26,13 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <property name="uri.var.versionId" expression="$func:versionId"/>
         <property name="uri.var.query" value=""/>
         <!-- urlRemainder needs to be sent to generate authentication code -->
-        <property name="uri.var.uriRemainder" expression="fn:concat('/', $ctx:uri.var.objectName, '/')"/>
+        <property name="uri.var.uriRemainder" expression="fn:concat('/', $ctx:uri.var.encodedObjectName, '/')"/>
         <filter xpath="string(uri.var.versionId) and uri.var.versionId != ''">
             <then>
                 <property name="uri.var.query"
@@ -70,7 +70,7 @@
         </filter>
         <call>
             <endpoint>
-                <http method="delete" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}{+uri.var.query}"/>
+                <http method="delete" uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}/{+uri.var.query}"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/deleteObject.xml
+++ b/src/main/resources/objects/deleteObject.xml
@@ -23,6 +23,12 @@
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.versionId" expression="$func:versionId"/>
         <property name="uri.var.query" value=""/>
         <!-- urlRemainder needs to be sent to generate authentication code -->

--- a/src/main/resources/objects/getObject.xml
+++ b/src/main/resources/objects/getObject.xml
@@ -48,10 +48,10 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
-        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <property name="uri.var.query" value=""/>
 
         <!-- Authentication Header Setup -->
@@ -155,7 +155,7 @@
                 <call>
                     <endpoint>
                         <http method="get"
-                              uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}{+uri.var.query}"
+                              uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}{+uri.var.query}"
                               format="pox"/>
                     </endpoint>
                 </call>

--- a/src/main/resources/objects/getObject.xml
+++ b/src/main/resources/objects/getObject.xml
@@ -45,8 +45,15 @@
         <property name="uri.var.ifMatch" expression="$func:ifMatch"/>
         <property name="uri.var.ifNoneMatch" expression="$func:ifNoneMatch"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
         <property name="uri.var.query" value=""/>
+
         <!-- Authentication Header Setup -->
         <class name="org.wso2.carbon.connector.amazons3.auth.AmazonS3AuthConnector"/>
         <!-- Properties Assigned in AmazonS3AuthConnector -->
@@ -147,7 +154,8 @@
             <else>
                 <call>
                     <endpoint>
-                        <http method="get" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}{+uri.var.query}"
+                        <http method="get"
+                              uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}{+uri.var.query}"
                               format="pox"/>
                     </endpoint>
                 </call>

--- a/src/main/resources/objects/getObjectACL.xml
+++ b/src/main/resources/objects/getObjectACL.xml
@@ -25,10 +25,10 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
-        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <property name="uri.var.queryString" value="acl"/>
         <!-- Authentication Header Setup -->
         <class name="org.wso2.carbon.connector.amazons3.auth.AmazonS3AuthConnector"/>
@@ -56,7 +56,7 @@
         </filter>
         <call>
             <endpoint>
-                <http method="get" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}?acl"/>
+                <http method="get" uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}?acl"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/getObjectACL.xml
+++ b/src/main/resources/objects/getObjectACL.xml
@@ -22,6 +22,12 @@
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
         <property name="uri.var.queryString" value="acl"/>
         <!-- Authentication Header Setup -->

--- a/src/main/resources/objects/getObjectMetaData.xml
+++ b/src/main/resources/objects/getObjectMetaData.xml
@@ -36,6 +36,12 @@
         <property name="uri.var.ifMatch" expression="$func:ifMatch"/>
         <property name="uri.var.ifNoneMatch" expression="$func:ifNoneMatch"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
         <!-- Authentication Header Setup -->
         <class name="org.wso2.carbon.connector.amazons3.auth.AmazonS3AuthConnector"/>

--- a/src/main/resources/objects/getObjectMetaData.xml
+++ b/src/main/resources/objects/getObjectMetaData.xml
@@ -39,10 +39,10 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
-        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <!-- Authentication Header Setup -->
         <class name="org.wso2.carbon.connector.amazons3.auth.AmazonS3AuthConnector"/>
         <filter xpath="string($ctx:date) and $ctx:date != ''">
@@ -96,7 +96,7 @@
         </filter>
         <call>
             <endpoint>
-                <http method="head" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}"/>
+                <http method="head" uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/getObjectTorrent.xml
+++ b/src/main/resources/objects/getObjectTorrent.xml
@@ -22,6 +22,12 @@
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
         <property name="uri.var.queryString" value="torrent"/>
         <!-- Authentication Header Setup -->

--- a/src/main/resources/objects/getObjectTorrent.xml
+++ b/src/main/resources/objects/getObjectTorrent.xml
@@ -25,10 +25,10 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
-        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <property name="uri.var.queryString" value="torrent"/>
         <!-- Authentication Header Setup -->
         <class name="org.wso2.carbon.connector.amazons3.auth.AmazonS3AuthConnector"/>
@@ -56,7 +56,7 @@
         </filter>
         <call>
             <endpoint>
-                <http method="get" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}?torrent"/>
+                <http method="get" uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}?torrent"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/headObject.xml
+++ b/src/main/resources/objects/headObject.xml
@@ -37,6 +37,12 @@
         <property name="uri.var.ifMatch" expression="$func:ifMatch"/>
         <property name="uri.var.ifNoneMatch" expression="$func:ifNoneMatch"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
         <filter xpath="string($ctx:uri.var.addCharset)='true'">
             <then>

--- a/src/main/resources/objects/headObject.xml
+++ b/src/main/resources/objects/headObject.xml
@@ -40,10 +40,10 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
-        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <filter xpath="string($ctx:uri.var.addCharset)='true'">
             <then>
                 <property name="uri.var.contentType"
@@ -114,7 +114,7 @@
         <property name="NO_ENTITY_BODY" value="true" type="BOOLEAN" scope="axis2"/>
         <call>
             <endpoint>
-                <http method="head" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}"/>
+                <http method="head" uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/initMultipartUpload.xml
+++ b/src/main/resources/objects/initMultipartUpload.xml
@@ -33,6 +33,12 @@
         <property name="uri.var.contentEncoding" expression="$func:contentEncoding"/>
         <property name="uri.var.expires" expression="$func:expires"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uriRemainder"
                   expression="fn:concat('/',$ctx:uri.var.objectName)"/>
         <property name="uri.var.queryString" value="uploads"/>

--- a/src/main/resources/objects/initMultipartUpload.xml
+++ b/src/main/resources/objects/initMultipartUpload.xml
@@ -36,11 +36,11 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <property name="uri.var.uriRemainder"
-                  expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+                  expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <property name="uri.var.queryString" value="uploads"/>
 
         <!-- Sending an empty payload to support FORCE_POST_PUT_NOBODY property-->
@@ -85,7 +85,7 @@
         </filter>
         <call>
             <endpoint>
-                <http method="post" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}?{+uri.var.queryString}"/>
+                <http method="post" uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}?{+uri.var.queryString}"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/listParts.xml
+++ b/src/main/resources/objects/listParts.xml
@@ -27,6 +27,12 @@
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
         <property name="uri.var.maxParts" expression="$func:maxParts"/>
         <property name="uri.var.encodingType" expression="$func:encodingType"/>

--- a/src/main/resources/objects/listParts.xml
+++ b/src/main/resources/objects/listParts.xml
@@ -30,7 +30,7 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
@@ -38,7 +38,7 @@
         <property name="uri.var.encodingType" expression="$func:encodingType"/>
         <property name="uri.var.partNumberMarker" expression="$func:partNumberMarker"/>
         <property name="uri.var.uriRemainder"
-                  expression="fn:concat('/',$ctx:uri.var.objectName)"/>
+                  expression="fn:concat('/',$ctx:uri.var.encodedObjectName)"/>
         <property name="uri.var.query" value=""/>
         <!-- Authentication Header Setup -->
         <class name="org.wso2.carbon.connector.amazons3.auth.AmazonS3AuthConnector"/>
@@ -86,7 +86,8 @@
         </filter>
         <call>
             <endpoint>
-                <http method="get" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}?uploadId={+uri.var.uploadId}{+uri.var.query}"/>
+                <http method="get"
+                      uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}?uploadId={+uri.var.uploadId}{+uri.var.query}"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/restoreObject.xml
+++ b/src/main/resources/objects/restoreObject.xml
@@ -26,13 +26,13 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.numberOfDays" expression="$func:numberOfDays"/>
         <property name="uri.var.versionId" expression="$func:versionId"/>
-        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.objectName,'')"/>
+        <property name="uri.var.uriRemainder" expression="fn:concat('/',$ctx:uri.var.encodedObjectName,'')"/>
         <property name="uri.var.queryString" value="restore"/>
         <property name="uri.var.query" value=""/>
         <!-- Setting the ACL of a specified object version -->
@@ -90,7 +90,8 @@
         </filter>
         <call>
             <endpoint>
-                <http method="post" uri-template="{uri.var.bucketUrl}{+uri.var.uriRemainder}?{+uri.var.queryString}{+uri.var.query}"/>
+                <http method="post"
+                      uri-template="{uri.var.bucketUrl}/{+uri.var.objectName}?{+uri.var.queryString}{+uri.var.query}"/>
             </endpoint>
         </call>
         <!-- Remove response custom header information -->

--- a/src/main/resources/objects/restoreObject.xml
+++ b/src/main/resources/objects/restoreObject.xml
@@ -23,6 +23,12 @@
     <sequence>
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.numberOfDays" expression="$func:numberOfDays"/>
         <property name="uri.var.versionId" expression="$func:versionId"/>

--- a/src/main/resources/objects/uploadPart.xml
+++ b/src/main/resources/objects/uploadPart.xml
@@ -30,7 +30,7 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
@@ -44,8 +44,8 @@
         </filter>
         <script language="js">
             <![CDATA[
-            var objectName=mc.getProperty('uri.var.objectName');
-            mc.setProperty('uri.var.uriRemainder', '/'+objectName);
+            var encodedObjectName=mc.getProperty('uri.var.encodedObjectName');
+            mc.setProperty('uri.var.uriRemainder', '/'+encodedObjectName);
         ]]>
         </script>
         <class name="org.wso2.carbon.connector.amazons3.auth.AmazonS3AuthConnector"/>

--- a/src/main/resources/objects/uploadPart.xml
+++ b/src/main/resources/objects/uploadPart.xml
@@ -27,6 +27,12 @@
         <property name="uri.var.uriRemainder" value=""/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
         <property name="uri.var.partNumber" expression="$func:partNumber"/>
         <property name="uri.var.body" expression="$func:body"/>

--- a/src/main/resources/objects/uploadPartCopy.xml
+++ b/src/main/resources/objects/uploadPartCopy.xml
@@ -24,6 +24,12 @@
         <class name="org.wso2.carbon.connector.amazons3.auth.RemoveAmazonS3Context"/>
         <property name="uri.var.bucketUrl" expression="$func:bucketUrl"/>
         <property name="uri.var.objectName" expression="$func:objectName"/>
+        <script language="js">
+            <![CDATA[
+            var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
+                mc.setProperty('uri.var.objectName' , encodedObjectName);
+        ]]>
+        </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
         <property name="uri.var.partNumber" expression="$func:partNumber"/>
         <property name="uri.var.uriRemainder" value=""/>

--- a/src/main/resources/objects/uploadPartCopy.xml
+++ b/src/main/resources/objects/uploadPartCopy.xml
@@ -27,7 +27,7 @@
         <script language="js">
             <![CDATA[
             var encodedObjectName = encodeURIComponent(mc.getProperty('uri.var.objectName'));
-                mc.setProperty('uri.var.objectName' , encodedObjectName);
+                mc.setProperty('uri.var.encodedObjectName' , encodedObjectName);
         ]]>
         </script>
         <property name="uri.var.uploadId" expression="$func:uploadId"/>
@@ -35,8 +35,8 @@
         <property name="uri.var.uriRemainder" value=""/>
         <script language="js">
             <![CDATA[
-            var objectName=mc.getProperty('uri.var.objectName');
-            mc.setProperty('uri.var.uriRemainder', '/'+objectName);
+            var encodedObjectName=mc.getProperty('uri.var.encodedObjectName');
+            mc.setProperty('uri.var.uriRemainder', '/'+encodedObjectName);
         ]]>
         </script>
         <filter xpath="string($ctx:uri.var.addCharset)='true'">

--- a/src/test/java/org/wso2/carbon/connector/integration/test/amazons3/AmazonS3ConnectorIntegrationTest.java
+++ b/src/test/java/org/wso2/carbon/connector/integration/test/amazons3/AmazonS3ConnectorIntegrationTest.java
@@ -1043,7 +1043,7 @@ public class AmazonS3ConnectorIntegrationTest extends ConnectorIntegrationTestBa
         esbRequestHeadersMap.put("Content-Type", "application/xml");
 
         RestResponse<OMElement> esbRestResponse = sendXmlRestRequest(proxyUrl, "POST", esbRequestHeadersMap,
-                        "createBucketLifecycle_mandatory.xml");
+                        "createBucketLifeCycle_mandatory.xml");
 
         Assert.assertEquals(esbRestResponse.getHttpStatusCode(), 200);
     }
@@ -1463,7 +1463,7 @@ public class AmazonS3ConnectorIntegrationTest extends ConnectorIntegrationTestBa
         esbRequestHeadersMap.put("Content-Type", "application/xml");
 
         RestResponse<OMElement> esbRestResponse = sendXmlRestRequest(proxyUrl, "POST", esbRequestHeadersMap,
-                        "deleteBucketLifecycle_mandatory.xml");
+                        "deleteBucketLifeCycle_mandatory.xml");
 
         Assert.assertEquals(esbRestResponse.getHttpStatusCode(), 204);
     }

--- a/src/test/resources/artifacts/ESB/connector/config/amazons3.properties
+++ b/src/test/resources/artifacts/ESB/connector/config/amazons3.properties
@@ -2,8 +2,8 @@ proxyDirectoryRelativePath=/artifacts/ESB/config/proxies/amazons3/
 requestDirectoryRelativePath=/artifacts/ESB/config/restRequests/amazons3/
 resourceDirectoryRelativePath=/artifacts/ESB/config/resources/amazons3/
 
-accessKeyId=AKXXKJKSAGKLSK
-secretAccessKey=qHXBJSXxkjSQMnasd+340sd9sdO2s
+accessKeyId=AKougttyXT2GHXQM7G5EA
+secretAccessKey=qHZBBdscsszX3
 
 #According to the API Bucket Name should be lowercase.
 bucketName_1=testconbkt1


### PR DESCRIPTION
## Purpose
Amazon S3 connector throws signature validation error when the filename of the object retrieved contains spaces

ESB encodes the objectName when it has spaces, Hence encode the same objectName which is used to calculate the signature.

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Integration tests
   Fixed minor changes in integration test file.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes, no committed any keys

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
Java - 1.8
Ubuntu

## Learning
N/A