### PR TITLE
Make connector compatible with Micro Integrator

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazons3/auth/AmazonS3URLSignatureCreation.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/auth/AmazonS3URLSignatureCreation.java
@@ -28,7 +28,6 @@ import org.jets3t.service.utils.ServiceUtils;
 import org.wso2.carbon.connector.amazons3.constants.AmazonS3Constants;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.mediation.registry.WSO2Registry;
-import org.wso2.carbon.registry.core.exceptions.RegistryException;
 
 import java.io.IOException;
 import java.security.Security;
@@ -104,8 +103,8 @@ public class AmazonS3URLSignatureCreation extends AbstractConnector {
         } catch (ParseException pe) {
             storeErrorResponseStatus(messageContext, pe, AmazonS3Constants.INVALID_KEY_ERROR_CODE);
             handleException("Could not parse the date in correct format", pe, messageContext);
-        } catch (RegistryException re) {
-            handleException("No File in Registry", re, messageContext);
+        } catch (Exception e) {
+            handleException("Unexpected error occurred during Amazon S3 URL signature creation", e, messageContext);
         }
     }
 


### PR DESCRIPTION
## Purpose

Make the connector compatible with WSO2 Micro Integrator. 
As `org.wso2.carbon.registry.core.exceptions.RegistryException` is a kernel level class and WSO2 MI runtime does not have it, we cannot use it. 

Instead, used a generic exception so that connector is compatible with both EI and MI. 