### PR TITLE
Addition of custom amazon metadata now works properly

### DIFF
--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -237,7 +237,16 @@
         </filter>
         <filter xpath="string($ctx:uri.var.xAmzMeta) or $ctx:uri.var.xAmzMeta != ''">
             <then>
-                <property name="x-amz-meta-" expression="$ctx:uri.var.xAmzMeta" scope="transport" type="STRING"/>
+                <script language="js"><![CDATA[
+				var metadata = mc.getProperty("uri.var.xAmzMeta");
+				var metadata_list = metadata.split(',');
+				for(var i =0 ; i< metadata_list.length; i++){
+					var key_value = metadata_list[i].split(':');
+					if(key_value[1] && key_value[0]){
+						mc.setProperty("x-amz-meta-" + key_value[0], key_value[1],"transport");
+					}
+				}
+  ]]></script>
             </then>
         </filter>
         <filter xpath="string($ctx:uri.var.xAmzServeEncryption) or $ctx:uri.var.xAmzServeEncryption != ''">


### PR DESCRIPTION
## Purpose
Issue : https://github.com/wso2-extensions/esb-connector-amazons3/issues/45



## Goals
Amazon user metadata header are correctly writed. Multiple key/value pair are supported separated with ",".
New metadata headers are inserted in the signature.

## Approach
I create new http header for each key/value pair present in xAmzMeta parameter of init operation. 
Then in AmazonS3AuthConnector, I retrieve the value of property filled with xAmzMeta parameter (uri.var.xAmzMeta)
`<property name="uri.var.xAmzMeta" expression="$func:xAmzMeta"/>`.
I create a map with this value.
Then add it in `amzHeadersMap` map, and I prefix key with `x-amz-meta`.

## User stories


## Release note
Hard to write understandable english i'm not very confortable with english

## Documentation


## Training


## Certification


## Marketing


## Automation tests


## Security checks


## Samples


## Related PRs


## Migrations (if applicable)


## Test environment

 
## Learning
