### PR TITLE
Passing correct parameter for deleteObject operation

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
@@ -345,7 +345,7 @@ public class ObjectOperations extends AbstractConnector {
                     break;
                 case S3Constants.OPERATION_DELETE_OBJECT:
                     errorMessage = "Error while deleting the objects";
-                    deleteObject(operationName, s3Client, bucketName, operationName, mfa, versionId, requestPayer,
+                    deleteObject(operationName, s3Client, bucketName, objectKey, mfa, versionId, requestPayer,
                             bypassGovernanceRetentionObj, messageContext);
                     break;
                 case S3Constants.OPERATION_DELETE_OBJECTS:


### PR DESCRIPTION
## Purpose
Resolves issue 51

## Goals
Correct a bug in the invocation of the deleteObject operation.

## Approach
The function signature requires the objectKey to be passed. A bug was passing the operationName in the place of the objectKey. Probably a typo or copy-paste error. Fixed by renaming the variable used when calling the operation to use the actual value read from the messageContext.

## Release note
Fix a bug in deleteObject operation

## Documentation
N/A, documentation is correct this was a simple source code error.