### PR TITLE
Use the default credentials provider to extend functionality inside AWS environments

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
@@ -37,7 +37,6 @@ public class S3ConnectionHandler implements Connection {
                     .build();
         } else {
             return S3Client.builder()
-                    .credentialsProvider(EnvironmentVariableCredentialsProvider.create())
                     .region(Region.of(region))
                     .httpClientBuilder(UrlConnectionHttpClient.builder())
                     .build();


### PR DESCRIPTION
## Purpose
Resolves #53

## Goals
Allow the connector to use temporary credentials taken from the role calling the operation when used from inside AWS EC2 or AWS ECS.

## Approach
If there are no credentials specified during initialization of the connector, the mechanism falls back to using the AWS credential provider chain. Previously this used the EnvironmentVariableCredentialsProvider which is a subset of the available credentials provider. By not initializing a specific provider the AWS SDK uses the DefaultCredentialsProvider which looks up not only in system environment variables but also in the other valid locations for AWS credentials (the .aws/credentials file and EC2/ECS endpoints).

## User stories

## Release note
Allow usage of temporary credentials taken from EC2 or ECS roles

## Documentation
N/A, The documentation already specified that the AWS credentials were optional. This change only allows the connector to retrieve the credentials during run time from more possible locations.