### PR TITLE
Add option to set the content of the file via payload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.amazons3</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.1</version>
+    <version>2.0.2</version>
     <name>WSO2 Carbon - Mediation Library Connector For amazons3</name>
     <url>http://wso2.org</url>
     <properties>

--- a/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
@@ -5,7 +5,6 @@ import org.wso2.carbon.connector.amazons3.pojo.ConnectionConfiguration;
 import org.wso2.carbon.connector.core.connection.Connection;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;

--- a/src/main/resources/objects/multipartUpload.xml
+++ b/src/main/resources/objects/multipartUpload.xml
@@ -20,6 +20,7 @@
     <parameter name="objectKey" description="The name to give the newly created object."/>
     <parameter name="partDetails" description="This contains all the parts."/>
     <parameter name="filePath" description="Path of the file to be uploaded."/>
+    <parameter name="fileContent" description="Content of the file."/>
     <parameter name="requestPayer"
                description="Confirms that the requester knows that they will be charged for the request."/>
     <sequence>

--- a/src/main/resources/objects/putObject.xml
+++ b/src/main/resources/objects/putObject.xml
@@ -19,6 +19,7 @@
     <parameter name="bucketName" description="Name of the bucket."/>
     <parameter name="objectKey" description="The name to give for the newly created object."/>
     <parameter name="filePath" description="The path of the source file to be uploaded."/>
+    <parameter name="fileContent" description="Content of the file."/>
     <parameter name="acl"
                description="Canned ACL which defines the set of AWS accounts or groups are granted access and the type of access."/>
     <parameter name="cacheControl" description="Specifies caching behavior along the request/reply chain."/>

--- a/src/main/resources/objects/uploadPart.xml
+++ b/src/main/resources/objects/uploadPart.xml
@@ -23,6 +23,7 @@
     <parameter name="uploadId" description="This specifies the ID of the initiated multipart upload."/>
     <parameter name="partNumber" description="This specifies the number or the index of the uploaded tag."/>
     <parameter name="filePath" description="Path of the file to be uploaded."/>
+    <parameter name="fileContent" description="Content of the file."/>
     <parameter name="sseCustomerAlgorithm"
                description="The algorithm to use to when encrypting the object (for example, AES256)."/>
     <parameter name="sseCustomerKey"

--- a/src/main/resources/uischema/multipartUpload.json
+++ b/src/main/resources/uischema/multipartUpload.json
@@ -65,11 +65,22 @@
                 {
                   "type": "attribute",
                   "value": {
+                    "name": "fileContent",
+                    "displayName": "File Content",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The content of the file."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
                     "name": "filePath",
                     "displayName": "File Path",
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
-                    "required": "true",
+                    "required": "false",
                     "helpTip": "The file path to upload it as the object content."
                   }
                 },

--- a/src/main/resources/uischema/putObject.json
+++ b/src/main/resources/uischema/putObject.json
@@ -54,11 +54,22 @@
                 {
                   "type": "attribute",
                   "value": {
+                    "name": "fileContent",
+                    "displayName": "File Content",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The content of the file."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
                     "name": "filePath",
                     "displayName": "File Path",
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
-                    "required": "true",
+                    "required": "false",
                     "helpTip": "The path of the file to be uploaded."
                   }
                 },

--- a/src/main/resources/uischema/uploadPart.json
+++ b/src/main/resources/uischema/uploadPart.json
@@ -87,11 +87,22 @@
                 {
                   "type": "attribute",
                   "value": {
+                    "name": "fileContent",
+                    "displayName": "File Content",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The content of the file."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
                     "name": "filePath",
                     "displayName": "File Path",
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
-                    "required": "true",
+                    "required": "false",
                     "helpTip": "Path of the file to be uploaded."
                   }
                 }


### PR DESCRIPTION
## Purpose
Fixes https://github.com/wso2-extensions/esb-connector-amazons3/issues/55

## Goals
Add option to upload request payload

## User stories
You can use the `fileContent` parameter to set the content you need to upload to S3. This parameter is available for `putObject`, `multipartUpload` and `uploadPart` operations.

A sample configuration for the `putObject` operation is shown below,

```xml
<amazons3.putObject configKey="AMAZON_S3_CONNECTION_1">
    <bucketName>{$ctx:bucketName}</bucketName>
    <objectKey>{$ctx:objectKey}</objectKey>
    <fileContent>{$ctx:fileContent}</fileContent>
</amazons3.putObject>
```