### PR TITLE
Reading XML files having a prolog results in XML parsing errors

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazons3/convertors/S3POJOHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/convertors/S3POJOHandler.java
@@ -1386,7 +1386,13 @@ public class S3POJOHandler {
         if (charset == null) {
             charset = StandardCharsets.UTF_8;
         }
-        obj1.setContent(responseBytes.asString(charset));
+
+        String content = responseBytes.asString(charset);
+        if (XmlUtil.isXmlContent(contentType)) {
+            content = XmlUtil.removeProlog(content);
+        }
+
+        obj1.setContent(content);
         return obj1;
     }
 

--- a/src/main/java/org/wso2/carbon/connector/amazons3/utils/XmlUtil.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/utils/XmlUtil.java
@@ -1,5 +1,7 @@
 package org.wso2.carbon.connector.amazons3.utils;
 
+import org.apache.http.entity.ContentType;
+
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Marshaller;
@@ -26,5 +28,41 @@ public class XmlUtil {
             throw new RuntimeException(e);
         }
         return result;
+    }
+
+
+    /**
+     * is the contentType an XML-type ?!
+     *
+     * @param contentType the contentType to check
+     * @return true when its a family of an XML type
+     */
+    public static boolean isXmlContent(ContentType contentType) {
+        return contentType.equals(ContentType.TEXT_XML) ||
+                contentType.equals(ContentType.APPLICATION_ATOM_XML) ||
+                contentType.equals(ContentType.APPLICATION_SVG_XML) ||
+                contentType.equals(ContentType.APPLICATION_XHTML_XML) ||
+                contentType.equals(ContentType.APPLICATION_XML);
+    }
+
+    /**
+     * Remove the XML Prolog if the contentType is of
+     *
+     * @param content the content to strip the prolog from
+     * @return the content without XML-prolog
+     */
+    public static String removeProlog(String content) {
+        // Test if there is a prolog.
+        if (content.startsWith("<?")) { // Yes prolog!
+            // strip the prolog, where does it end?
+            String prologEndStr = "?>";
+            int endProlog = content.indexOf(prologEndStr);
+            if (endProlog > 0) {
+                // strip it off
+                return content.substring(endProlog + prologEndStr.length());
+            }
+        }
+
+        return content;
     }
 }


### PR DESCRIPTION
## Purpose
Resolves [#59](https://github.com/wso2-extensions/esb-connector-amazons3/issues/59)

## Goals
An XML-file having a prolog cannot currently be parsed properly downstream. The process complains about the XML-prolog being present mid-xml-document. This is caused by the String-to-XML conversion not removing the prolog.

## Approach
Once the file-data has been retrieved the logic determines if the contentType of the retrieved data is in the XML-family. If so then the prolog is searched for and removed from the top. This caused the message to be properly processed further downstream the integration logic.
