### PR TITLE
Add support for custom SDK host

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>org.wso2.carbon.connector</groupId>
     <artifactId>org.wso2.carbon.connector.amazons3</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.3</version>
+    <version>2.0.4</version>
     <name>WSO2 Carbon - Mediation Library Connector For amazons3</name>
     <url>http://wso2.org</url>
     <properties>
@@ -41,6 +41,8 @@
         <integration.base.version>1.0.3</integration.base.version>
         <skip-tests>true</skip-tests>
         <software.amazon.awssdk.version>2.14.12</software.amazon.awssdk.version>
+        <jaxb.core.version>2.2.10-b140802.1033</jaxb.core.version>
+        <jaxb.impl.version>2.0.1</jaxb.impl.version>
     </properties>
     <dependencies>
         <dependency>
@@ -174,6 +176,16 @@
             <groupId>org.wso2.ei</groupId>
             <artifactId>integration-test-utils</artifactId>
             <version>${product.ei.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-core</artifactId>
+            <version>${jaxb.core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.sun.xml.bind</groupId>
+            <artifactId>jaxb-impl</artifactId>
+            <version>${jaxb.impl.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.ei</groupId>

--- a/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
@@ -9,6 +9,9 @@ import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3ClientBuilder;
+
+import java.net.URI;
 
 public class S3ConnectionHandler implements Connection {
 
@@ -26,20 +29,20 @@ public class S3ConnectionHandler implements Connection {
         String region = this.connectionConfig.getRegion();
         String awsAccessKeyId = this.connectionConfig.getAwsAccessKeyId();
         String awsSecretAccessKey = this.connectionConfig.getAwsSecretAccessKey();
+        String host = this.connectionConfig.getHost();
+        S3ClientBuilder s3ClientBuilder = S3Client.builder();
         if (StringUtils.isNotEmpty(awsAccessKeyId) && StringUtils.isNotEmpty(awsSecretAccessKey)) {
             AwsCredentialsProvider credentialsProvider =
                     StaticCredentialsProvider.create(AwsBasicCredentials.create(awsAccessKeyId, awsSecretAccessKey));
-            return S3Client.builder()
-                    .credentialsProvider(credentialsProvider)
-                    .region(Region.of(region))
-                    .httpClientBuilder(UrlConnectionHttpClient.builder())
-                    .build();
-        } else {
-            return S3Client.builder()
-                    .region(Region.of(region))
-                    .httpClientBuilder(UrlConnectionHttpClient.builder())
-                    .build();
+            s3ClientBuilder
+                    .credentialsProvider(credentialsProvider);
         }
+        if (StringUtils.isNotEmpty(host)) {
+            s3ClientBuilder.endpointOverride(URI.create(host));
+        }
+
+        return s3ClientBuilder.region(Region.of(region))
+                .httpClientBuilder(UrlConnectionHttpClient.builder()).build();
     }
 
     public ConnectionConfiguration getConnectionConfig() {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/constants/S3Constants.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/constants/S3Constants.java
@@ -39,6 +39,8 @@ public class S3Constants {
      */
     public static final String AWS_SECRET_ACCESS_KEY = "awsSecretAccessKey";
 
+    public static final String HOST = "host";
+
     /**
      * Constant for connection name.
      */
@@ -109,4 +111,6 @@ public class S3Constants {
     public static final String OPERATION_RESTORE_OBJECT = "restoreObject";
     public static final String OPERATION_UPLOAD_PART = "uploadPart";
     public static final String OPERATION_UPLOAD_PART_COPY = "uploadPartCopy";
+
+    public static final String UTF_8 = "UTF-8";
 }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
@@ -13,6 +13,7 @@ import org.wso2.carbon.connector.amazons3.exception.InvalidConfigurationExceptio
 import org.wso2.carbon.connector.amazons3.pojo.S3OperationResult;
 import org.wso2.carbon.connector.amazons3.utils.Error;
 import org.wso2.carbon.connector.amazons3.utils.S3ConnectorUtils;
+import org.wso2.carbon.connector.amazons3.utils.XmlUtil;
 import org.wso2.carbon.connector.core.AbstractConnector;
 import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.connection.ConnectionHandler;
@@ -830,7 +831,12 @@ public class ObjectOperations extends AbstractConnector {
                 objectResponse = s3POJOHandler.castS3GetObjectResponseWithContent(responseBytes);
             }
             OMElement responseElement = S3ConnectorUtils.createOMElement("GetObjectResponse", "");
-            String objString = s3POJOHandler.getObjectAsXml(objectResponse,
+            XmlUtil xmlUtil = new XmlUtil();
+            String encoding = S3Constants.UTF_8;
+            if (objectResponse.getContentEncoding() != null) {
+                encoding = objectResponse.getContentEncoding();
+            }
+            String objString = xmlUtil.convertToXml(objectResponse, encoding,
                     org.wso2.carbon.connector.amazons3.pojo.GetObjectResponse.class);
             try {
                 responseElement = AXIOMUtil.stringToOM(objString);

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
@@ -63,12 +63,14 @@ public class S3Config extends AbstractConnector implements ManagedLifecycle {
                 lookupTemplateParamater(msgContext, S3Constants.AWS_ACCESS_KEY_ID);
         String awsSecretAccessKey = (String) ConnectorUtils.
                 lookupTemplateParamater(msgContext, S3Constants.AWS_SECRET_ACCESS_KEY);
+        String host = (String) ConnectorUtils.lookupTemplateParamater(msgContext, S3Constants.HOST);
 
         ConnectionConfiguration connectionConfig = new ConnectionConfiguration();
         connectionConfig.setConnectionName(connectionName);
         connectionConfig.setRegion(region);
         connectionConfig.setAwsAccessKeyId(awsAccessKeyId);
         connectionConfig.setAwsSecretAccessKey(awsSecretAccessKey);
+        connectionConfig.setHost(host);
         return connectionConfig;
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ConnectionConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ConnectionConfiguration.java
@@ -32,6 +32,8 @@ public class ConnectionConfiguration {
     private String awsAccessKeyId;
     private String awsSecretAccessKey;
 
+    private String host;
+
     public String getConnectionName() {
         return connectionName;
     }
@@ -72,4 +74,12 @@ public class ConnectionConfiguration {
         this.awsSecretAccessKey = awsSecretAccessKey;
     }
 
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
 }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/utils/XmlUtil.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/utils/XmlUtil.java
@@ -6,7 +6,14 @@ import javax.xml.bind.Marshaller;
 import javax.xml.transform.Transformer;
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.XMLConstants;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.io.Writer;
+
+import com.sun.xml.bind.marshaller.CharacterEscapeHandler;
+import com.sun.xml.bind.marshaller.DataWriter;
 
 public class XmlUtil {
     public String convertToXml(Object source, Class... type) {
@@ -26,5 +33,38 @@ public class XmlUtil {
             throw new RuntimeException(e);
         }
         return result;
+    }
+
+    public String convertToXml(Object source, String encoding, Class... type) {
+        String result = "";
+        StringWriter sw = new StringWriter();
+        try {
+            TransformerFactory transformerFactory = TransformerFactory.newInstance();
+            transformerFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            Transformer transformer = transformerFactory.newTransformer();
+            transformer.setOutputProperty("omit-xml-declaration", "yes");
+
+            JAXBContext context = JAXBContext.newInstance(type);
+            Marshaller marshaller = context.createMarshaller();
+            marshaller.setProperty(Marshaller.JAXB_FRAGMENT, Boolean.TRUE);
+
+            // The below code will take care of avoiding the conversion of < to &lt; and > to &gt; etc
+            PrintWriter printWriter = new PrintWriter(sw);
+            DataWriter dataWriter = new DataWriter(printWriter, encoding, new JaxbCharacterEscapeHandler());
+
+            marshaller.marshal(source, dataWriter);
+            result = sw.toString();
+        } catch (JAXBException | TransformerConfigurationException e) {
+            throw new RuntimeException(e);
+        }
+        return result;
+    }
+
+    static class JaxbCharacterEscapeHandler implements CharacterEscapeHandler {
+        @Override
+        public void escape(char[] buf, int start, int len, boolean isAttValue, Writer out) throws IOException {
+            out.write(buf,start,len);
+
+        }
     }
 }

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -20,6 +20,7 @@
     <parameter name="region" description="Region which is used select a regional endpoint to make requests"/>
     <parameter name="awsAccessKeyId" description="AWS access key ID"/>
     <parameter name="awsSecretAccessKey" description="AWS secret key"/>
+    <parameter name="host" description="AWS SDK host"/>
     <sequence>
         <property name="name" expression="$func:name"/>
         <class name="org.wso2.carbon.connector.amazons3.operations.S3Config"/>

--- a/src/main/resources/uischema/connection.json
+++ b/src/main/resources/uischema/connection.json
@@ -58,6 +58,17 @@
                     "required": "true",
                     "helpTip": "Region which is used select a regional endpoint to make requests."
                   }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "host",
+                    "displayName": "Host",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "For path-style requests, the value is s3.amazonaws.com. For virtual-style requests, the value is BucketName.s3.amazonaws.com."
+                  }
                 }
               ]
             }


### PR DESCRIPTION
This PR is to solve the following two issues:
Fix: https://github.com/wso2/api-manager/issues/1442, https://github.com/wso2/api-manager/issues/1396
- AWS SDK cannot connect with custom IAM accounts with custom host names. This PR let Custom host defined with <host> parameter in connector configurations. Default configs will be kept as it is if the host is not defined.
- XML documents on S3 bucket reading having a problem where connector convert `<` signs to `&lt;`. This fix avoids escape encoding these characters and keeps the value as it is.