### PR TITLE
Use String for timestamp when serializing to XML

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/Bucket.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/Bucket.java
@@ -37,8 +37,8 @@ public class Bucket {
     }
 
     @XmlElement(name = "CreationDate")
-    public Instant getCreationDate() {
-        return creationDate;
+    public String getCreationDate() {
+        return (creationDate != null) ? creationDate.toString() : "";
     }
 
     public void setCreationDate(Instant creationDate) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/CopyObjectResult.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/CopyObjectResult.java
@@ -37,8 +37,8 @@ public class CopyObjectResult {
     }
 
     @XmlElement(name = "LastModified")
-    public Instant getLastModified() {
-        return lastModified;
+    public String getLastModified() {
+        return (lastModified != null) ? lastModified.toString() : "";
     }
 
     public void setLastModified(Instant lastModified) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/CopyPartResult.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/CopyPartResult.java
@@ -37,8 +37,8 @@ public class CopyPartResult {
     }
 
     @XmlElement(name = "LastModified")
-    public Instant getLastModified() {
-        return lastModified;
+    public String getLastModified() {
+        return (lastModified != null) ? lastModified.toString() : "";
     }
 
     public void setLastModified(Instant lastModified) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/CreateMultipartUploadResponse.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/CreateMultipartUploadResponse.java
@@ -37,8 +37,8 @@ public class CreateMultipartUploadResponse {
     private String ssekmsEncryptionContext;
 
     @XmlElement(name = "AbortDate")
-    public Instant getAbortDate() {
-        return abortDate;
+    public String getAbortDate() {
+        return (abortDate != null) ? abortDate.toString() : "";
     }
 
     public void setAbortDate(Instant abortDate) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/DeleteMarkerEntry.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/DeleteMarkerEntry.java
@@ -67,8 +67,8 @@ public class DeleteMarkerEntry {
     }
 
     @XmlElement(name = "LastModified")
-    public Instant getLastModified() {
-        return lastModified;
+    public String getLastModified() {
+        return (lastModified != null) ? lastModified.toString() : "";
     }
 
     public void setLastModified(Instant lastModified) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/GetObjectResponse.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/GetObjectResponse.java
@@ -94,8 +94,8 @@ public class GetObjectResponse {
     }
 
     @XmlElement(name = "LastModified")
-    public Instant getLastModified() {
-        return lastModified;
+    public String getLastModified() {
+        return (lastModified != null) ? lastModified.toString() : "";
     }
 
     public void setLastModified(Instant lastModified) {
@@ -193,8 +193,8 @@ public class GetObjectResponse {
     }
 
     @XmlElement(name = "Expires")
-    public Instant getExpires() {
-        return expires;
+    public String getExpires() {
+        return (expires != null) ? expires.toString() : "";
     }
 
     public void setExpires(Instant expires) {
@@ -310,8 +310,8 @@ public class GetObjectResponse {
     }
 
     @XmlElement(name = "ObjectLockRetainUntilDate")
-    public Instant getObjectLockRetainUntilDate() {
-        return objectLockRetainUntilDate;
+    public String getObjectLockRetainUntilDate() {
+        return (objectLockRetainUntilDate != null) ? objectLockRetainUntilDate.toString() : "";
     }
 
     public void setObjectLockRetainUntilDate(Instant objectLockRetainUntilDate) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/HeadObjectResponse.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/HeadObjectResponse.java
@@ -91,8 +91,8 @@ public class HeadObjectResponse {
     }
 
     @XmlElement(name = "LastModified")
-    public Instant getLastModified() {
-        return lastModified;
+    public String getLastModified() {
+        return (lastModified != null) ? lastModified.toString() : "";
     }
 
     public void setLastModified(Instant lastModified) {
@@ -181,8 +181,8 @@ public class HeadObjectResponse {
     }
 
     @XmlElement(name = "Expires")
-    public Instant getExpires() {
-        return expires;
+    public String getExpires() {
+        return (expires != null) ? expires.toString() : "";
     }
 
     public void setExpires(Instant expires) {
@@ -289,8 +289,8 @@ public class HeadObjectResponse {
     }
 
     @XmlElement(name = "ObjectLockRetainUntilDate")
-    public Instant getObjectLockRetainUntilDate() {
-        return objectLockRetainUntilDate;
+    public String getObjectLockRetainUntilDate() {
+        return (objectLockRetainUntilDate != null) ? objectLockRetainUntilDate.toString() : "";
     }
 
     public void setObjectLockRetainUntilDate(Instant objectLockRetainUntilDate) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/LifecycleExpiration.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/LifecycleExpiration.java
@@ -29,6 +29,10 @@ public class LifecycleExpiration {
     private int days;
 
     @XmlElement(name = "Date")
+    public String getDateAsString() {
+        return (date != null) ? date.toString() : "";
+    }
+
     public Instant getDate() {
         return date;
     }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/MultipartUpload.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/MultipartUpload.java
@@ -41,8 +41,8 @@ public class MultipartUpload {
     }
 
     @XmlElement(name = "Initiated")
-    public Instant getInitiated() {
-        return initiated;
+    public String getInitiated() {
+        return (initiated != null) ? initiated.toString() : "";
     }
 
     public void setInitiated(Instant initiated) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ObjectVersion.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ObjectVersion.java
@@ -88,8 +88,8 @@ public class ObjectVersion {
     }
 
     @XmlElement(name = "LastModified")
-    public Instant getLastModified() {
-        return lastModified;
+    public String getLastModified() {
+        return (lastModified != null) ? lastModified.toString() : "";
     }
 
     public void setLastModified(Instant lastModified) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/Part.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/Part.java
@@ -30,6 +30,10 @@ public class Part {
     private long size;
 
     @XmlElement(name = "LastModified")
+    public String getLastModifiedAsString() {
+        return (lastModified != null) ? lastModified.toString() : "";
+    }
+
     public Instant getLastModified() {
         return lastModified;
     }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/PartsConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/PartsConfiguration.java
@@ -51,8 +51,8 @@ public class PartsConfiguration {
 
 
     @XmlElement(name = "AbortDate")
-    public Instant getAbortDate() {
-        return abortDate;
+    public String getAbortDate() {
+        return (abortDate != null) ? abortDate.toString() : "";
     }
 
     public void setAbortDate(Instant abortDate) {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/S3Object.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/S3Object.java
@@ -68,11 +68,12 @@ public class S3Object {
     }
 
     @XmlElement(name = "LastModified")
-    public Instant getLastModified() {
-        return lastModified;
+    public String getLastModified() {
+        return (lastModified != null) ? lastModified.toString() : "";
     }
 
     public void setLastModified(Instant lastModified) {
+
         this.lastModified = lastModified;
     }
 

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/Transition.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/Transition.java
@@ -28,9 +28,13 @@ public class Transition {
     private String storageClass;
     private int days;
 
-    @XmlElement(name = "Date")
     public Instant getDate() {
         return date;
+    }
+
+    @XmlElement(name = "Date")
+    public String getDateAsString() {
+        return (date != null) ? date.toString() : "";
     }
 
     public void setDate(Instant date) {


### PR DESCRIPTION
## Purpose

Since JAXB don't support java.time.* objects, when serializing the S3 response Object to XML, the timestamps become empty. With this fix we convert the Instant value to string before serializing.

Fixes: https://github.com/wso2/api-manager/issues/2502
