### PR TITLE
Adding role based authentication to S3 connector

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -228,11 +228,11 @@
             <artifactId>url-connection-client</artifactId>
             <version>${software.amazon.awssdk.version}</version>
         </dependency>
-		<dependency>
-		    <groupId>software.amazon.awssdk</groupId>
-		    <artifactId>sts</artifactId>
-		    <version>${software.amazon.awssdk.version}</version>
-		</dependency>
+	<dependency>
+	    <groupId>software.amazon.awssdk</groupId>
+	    <artifactId>sts</artifactId>
+	    <version>${software.amazon.awssdk.version}</version>
+	</dependency>
         <dependency>
             <groupId>org.wso2.carbon.mediation</groupId>
             <artifactId>org.wso2.carbon.connector.core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -228,6 +228,11 @@
             <artifactId>url-connection-client</artifactId>
             <version>${software.amazon.awssdk.version}</version>
         </dependency>
+		<dependency>
+		    <groupId>software.amazon.awssdk</groupId>
+		    <artifactId>sts</artifactId>
+		    <version>${software.amazon.awssdk.version}</version>
+		</dependency>
         <dependency>
             <groupId>org.wso2.carbon.mediation</groupId>
             <artifactId>org.wso2.carbon.connector.core</artifactId>

--- a/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
@@ -39,7 +39,7 @@ public class S3ConnectionHandler implements Connection {
         String roleSessionName = this.connectionConfig.getRoleSessionName();
         S3ClientBuilder s3ClientBuilder = S3Client.builder();
         // This is used to access the buckets with a cross account role
-        if (StringUtils.isNotEmpty(roleArn) && StringUtils.isNotBlank(roleSessionName)) {
+        if (StringUtils.isNotBlank(roleArn) && StringUtils.isNotBlank(roleSessionName)) {
 		StsClient stsClient = StsClient.create();
             AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
                     .roleArn(roleArn)

--- a/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
@@ -5,12 +5,16 @@ import org.wso2.carbon.connector.amazons3.pojo.ConnectionConfiguration;
 import org.wso2.carbon.connector.core.connection.Connection;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
 
 import java.net.URI;
 
@@ -31,19 +35,39 @@ public class S3ConnectionHandler implements Connection {
         String awsAccessKeyId = this.connectionConfig.getAwsAccessKeyId();
         String awsSecretAccessKey = this.connectionConfig.getAwsSecretAccessKey();
         String host = this.connectionConfig.getHost();
+        String roleArn = this.connectionConfig.getRoleArn();
+        String roleSessionName = this.connectionConfig.getRoleSessionName();
         S3ClientBuilder s3ClientBuilder = S3Client.builder();
-        if (StringUtils.isNotEmpty(awsAccessKeyId) && StringUtils.isNotEmpty(awsSecretAccessKey)) {
-            AwsCredentialsProvider credentialsProvider =
-                    StaticCredentialsProvider.create(AwsBasicCredentials.create(awsAccessKeyId, awsSecretAccessKey));
-            s3ClientBuilder
-                    .credentialsProvider(credentialsProvider);
-        }
-        if (StringUtils.isNotEmpty(host)) {
-            s3ClientBuilder.endpointOverride(URI.create(host));
-        }
+        // This is used to access the buckets with a cross account role
+        if (StringUtils.isNotEmpty(roleArn) && StringUtils.isNotBlank(roleSessionName)) {
+		StsClient stsClient = StsClient.create();
+            AssumeRoleRequest assumeRoleRequest = AssumeRoleRequest.builder()
+                    .roleArn(roleArn)
+                    .roleSessionName(roleSessionName)
+                    .build();
+            AssumeRoleResponse response = stsClient.assumeRole(assumeRoleRequest);
+            AwsSessionCredentials temporaryCredentials = AwsSessionCredentials.create(
+                    response.credentials().accessKeyId(),
+                    response.credentials().secretAccessKey(),
+                    response.credentials().sessionToken());
+            return s3ClientBuilder.region(Region.of(region))
+                    .credentialsProvider(StaticCredentialsProvider.create(temporaryCredentials))
+                    .build();
+        } else {
+		if (StringUtils.isNotEmpty(awsAccessKeyId) && StringUtils.isNotEmpty(awsSecretAccessKey)) {
+			AwsCredentialsProvider credentialsProvider =
+					StaticCredentialsProvider.create(AwsBasicCredentials.create(awsAccessKeyId, awsSecretAccessKey));
+			s3ClientBuilder
+			.credentialsProvider(credentialsProvider);
+		}
 
-        return s3ClientBuilder.region(Region.of(region))
-                .httpClientBuilder(UrlConnectionHttpClient.builder()).build();
+		if (StringUtils.isNotEmpty(host)) {
+			s3ClientBuilder.endpointOverride(URI.create(host));
+		}
+
+		return s3ClientBuilder.region(Region.of(region))
+				.httpClientBuilder(UrlConnectionHttpClient.builder()).build();
+        }
     }
 
     public ConnectionConfiguration getConnectionConfig() {

--- a/src/main/java/org/wso2/carbon/connector/amazons3/constants/S3Constants.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/constants/S3Constants.java
@@ -41,6 +41,10 @@ public class S3Constants {
 
     public static final String HOST = "host";
 
+    public static final String ROLE_ARN = "roleArn";
+
+    public static final String ROLE_SESSION_NAME = "roleSessionName";
+
     /**
      * Constant for connection name.
      */

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
@@ -64,6 +64,8 @@ public class S3Config extends AbstractConnector implements ManagedLifecycle {
         String awsSecretAccessKey = (String) ConnectorUtils.
                 lookupTemplateParamater(msgContext, S3Constants.AWS_SECRET_ACCESS_KEY);
         String host = (String) ConnectorUtils.lookupTemplateParamater(msgContext, S3Constants.HOST);
+        String roleArn = (String) ConnectorUtils.lookupTemplateParamater(msgContext, S3Constants.ROLE_ARN);
+        String roleSessionName = (String) ConnectorUtils.lookupTemplateParamater(msgContext, S3Constants.ROLE_SESSION_NAME);
 
         ConnectionConfiguration connectionConfig = new ConnectionConfiguration();
         connectionConfig.setConnectionName(connectionName);
@@ -71,6 +73,8 @@ public class S3Config extends AbstractConnector implements ManagedLifecycle {
         connectionConfig.setAwsAccessKeyId(awsAccessKeyId);
         connectionConfig.setAwsSecretAccessKey(awsSecretAccessKey);
         connectionConfig.setHost(host);
+        connectionConfig.setRoleArn(roleArn);
+        connectionConfig.setRoleSessionName(roleSessionName);
         return connectionConfig;
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ConnectionConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ConnectionConfiguration.java
@@ -87,19 +87,19 @@ public class ConnectionConfiguration {
         this.host = host;
     }
 
-	public String getRoleArn() {
-		return roleArn;
-	}
+    public String getRoleArn() {
+        return roleArn;
+    }
 
-	public void setRoleArn(String roleArn) {
-		this.roleArn = roleArn;
-	}
+    public void setRoleArn(String roleArn) {
+        this.roleArn = roleArn;
+    }
 
-	public String getRoleSessionName() {
-		return roleSessionName;
-	}
+    public String getRoleSessionName() {
+        return roleSessionName;
+    }
 
-	public void setRoleSessionName(String roleSessionName) {
-		this.roleSessionName = roleSessionName;
-	}
+    public void setRoleSessionName(String roleSessionName) {
+        this.roleSessionName = roleSessionName;
+    }
 }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ConnectionConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ConnectionConfiguration.java
@@ -34,6 +34,10 @@ public class ConnectionConfiguration {
 
     private String host;
 
+    private String roleArn;
+
+    private String roleSessionName;
+
     public String getConnectionName() {
         return connectionName;
     }
@@ -82,4 +86,20 @@ public class ConnectionConfiguration {
     public void setHost(String host) {
         this.host = host;
     }
+
+	public String getRoleArn() {
+		return roleArn;
+	}
+
+	public void setRoleArn(String roleArn) {
+		this.roleArn = roleArn;
+	}
+
+	public String getRoleSessionName() {
+		return roleSessionName;
+	}
+
+	public void setRoleSessionName(String roleSessionName) {
+		this.roleSessionName = roleSessionName;
+	}
 }

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -21,6 +21,8 @@
     <parameter name="awsAccessKeyId" description="AWS access key ID"/>
     <parameter name="awsSecretAccessKey" description="AWS secret key"/>
     <parameter name="host" description="AWS SDK host"/>
+    <parameter name="roleArn" description="AWS role ARN"/>
+    <parameter name="roleSessionName"description="AWS role session name"/>
     <sequence>
         <property name="name" expression="$func:name"/>
         <class name="org.wso2.carbon.connector.amazons3.operations.S3Config"/>


### PR DESCRIPTION
## Purpose
> Adding support to authenticate S3 operations based on the roles assigned to the EC2 instances


## Test environment
> This change was done mainly done for Pekin. The changes were tested only in the customer environment. In order to test the changes after merging to the S3 connector code, we will have to provide a pre-qa fix to Pekin and get it tested in their environment. 
 