### PR TITLE
Improve putObject to support binary content in the envelope

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazons3/convertors/S3POJOHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/convertors/S3POJOHandler.java
@@ -1824,6 +1824,7 @@ public class S3POJOHandler {
         obj1.setRequestCharged(obj.requestChargedAsString());
         obj1.setServerSideEncryption(obj.serverSideEncryptionAsString());
         obj1.setSsekmsKeyId(obj.ssekmsKeyId());
+        obj1.setVersionId(obj.versionId());
         return obj1;
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/convertors/S3POJOHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/convertors/S3POJOHandler.java
@@ -1813,4 +1813,17 @@ public class S3POJOHandler {
         obj1.setExpiration(obj.expiration().toString());
         return obj1;
     }
+
+    public org.wso2.carbon.connector.amazons3.pojo.PutObjectResponse castS3CompleteMultipartUploadResponseToPutObjectResponse(
+            CompleteMultipartUploadResponse obj) {
+
+        org.wso2.carbon.connector.amazons3.pojo.PutObjectResponse obj1 =
+                new org.wso2.carbon.connector.amazons3.pojo.PutObjectResponse();
+        obj1.setETag(obj.eTag());
+        obj1.setExpiration(obj.expiration());
+        obj1.setRequestCharged(obj.requestChargedAsString());
+        obj1.setServerSideEncryption(obj.serverSideEncryptionAsString());
+        obj1.setSsekmsKeyId(obj.ssekmsKeyId());
+        return obj1;
+    }
 }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
@@ -128,6 +128,7 @@ public class ObjectOperations extends AbstractConnector {
         RequestBody s3RequestBody = null;
         boolean useStreamingMultipart = false;
         InputStream streamInputStream = null;
+        InputStream dataHandlerInputStream = null;
         long streamingThresholdValue = STREAMING_MULTIPART_THRESHOLD;
         int streamingPartSizeValue = STREAMING_PART_SIZE;
         List<Part> s3PartDetails = new ArrayList<>();
@@ -287,6 +288,7 @@ public class ObjectOperations extends AbstractConnector {
                                     (javax.activation.DataHandler) omText.getDataHandler();
                             try {
                                 InputStream inputStream = dataHandler.getInputStream();
+                                dataHandlerInputStream = inputStream;
                                 Object fileSizeObj = messageContext.getProperty("FILE_SIZE");
                                 long contentLength = fileSizeObj instanceof Long
                                         ? (Long) fileSizeObj : -1L;
@@ -617,6 +619,14 @@ public class ObjectOperations extends AbstractConnector {
 
             S3ConnectorUtils.setResultAsPayload(messageContext, result);
             handleException(errorMessage, e, messageContext);
+        } finally {
+            if (dataHandlerInputStream != null) {
+                try {
+                    dataHandlerInputStream.close();
+                } catch (IOException e) {
+                    log.warn("Failed to close DataHandler InputStream: " + e.getMessage());
+                }
+            }
         }
     }
 
@@ -1426,6 +1436,12 @@ public class ObjectOperations extends AbstractConnector {
                     operationName, false, Error.CONNECTION_ERROR,
                     "Error occurred while accessing the AWS SDK service: " + e.getMessage()));
             handleException("Error occurred while accessing the AWS SDK service", e, messageContext);
+        } finally {
+            try {
+                inputStream.close();
+            } catch (IOException e) {
+                log.warn("Failed to close InputStream after streaming multipart upload: " + e.getMessage());
+            }
         }
     }
 

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
@@ -263,6 +263,10 @@ public class ObjectOperations extends AbstractConnector {
             enableStreaming = (String) ConnectorUtils.
                     lookupTemplateParamater(messageContext, "enableStreaming");
             if (Boolean.parseBoolean(enableStreaming) && s3RequestBody == null) {
+                if (log.isDebugEnabled()) {
+                    log.debug("Streaming upload enabled. Attempting to read content from message body" +
+                            " for operation: " + operationName);
+                }
                 org.apache.axis2.context.MessageContext axis2MsgCtx =
                         ((org.apache.synapse.core.axis2.Axis2MessageContext) messageContext)
                                 .getAxis2MessageContext();
@@ -270,8 +274,15 @@ public class ObjectOperations extends AbstractConnector {
                 if (binaryElement != null) {
                     org.apache.axiom.om.OMNode firstChild = binaryElement.getFirstOMChild();
                     if (firstChild instanceof org.apache.axiom.om.OMText) {
+                        if (log.isDebugEnabled()) {
+                            log.debug("Found streaming content in message body for operation: " + operationName);
+                        }
                         org.apache.axiom.om.OMText omText = (org.apache.axiom.om.OMText) firstChild;
                         if (omText.isOptimized()) {
+                            if (log.isDebugEnabled()) {
+                                log.debug("Message body content is optimized for streaming " +
+                                        "for operation: " + operationName);
+                            }
                             javax.activation.DataHandler dataHandler =
                                     (javax.activation.DataHandler) omText.getDataHandler();
                             try {
@@ -279,9 +290,17 @@ public class ObjectOperations extends AbstractConnector {
                                 Object fileSizeObj = messageContext.getProperty("FILE_SIZE");
                                 long contentLength = fileSizeObj instanceof Long
                                         ? (Long) fileSizeObj : -1L;
+                                if (log.isDebugEnabled()) {
+                                    log.debug("Content length of the streaming data: " + contentLength +
+                                            " for operation: " + operationName);
+                                }
                                 if (StringUtils.isNotEmpty(streamingThreshold)) {
                                     try {
                                         streamingThresholdValue = Long.parseLong(streamingThreshold);
+                                        if (log.isDebugEnabled()) {
+                                            log.debug("Using custom streaming threshold value: " +
+                                                    streamingThresholdValue + " for operation: " + operationName);
+                                        }
                                     } catch (NumberFormatException e) {
                                         errorMessage = "Invalid streaming threshold value: " + streamingThreshold;
                                         throw new InvalidConfigurationException("Invalid streaming threshold value: "
@@ -289,11 +308,19 @@ public class ObjectOperations extends AbstractConnector {
                                     }
                                 }
                                 if (contentLength < 0 || contentLength >= streamingThresholdValue) {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("Content length is above the streaming threshold. " +
+                                                "Using streaming multipart upload for operation: " + operationName);
+                                    }
                                     useStreamingMultipart = true;
                                     streamInputStream = inputStream;
                                     if (StringUtils.isNotEmpty(streamingPartSize)) {
                                         try {
                                             streamingPartSizeValue = Integer.parseInt(streamingPartSize);
+                                            if (log.isDebugEnabled()) {
+                                                log.debug("Using custom streaming part size value: " +
+                                                        streamingPartSizeValue + " for operation: " + operationName);
+                                            }
                                         } catch (NumberFormatException e) {
                                             errorMessage = "Invalid streaming part size value: " + streamingPartSize;
                                             throw new InvalidConfigurationException("Invalid streaming part size value: "
@@ -301,6 +328,10 @@ public class ObjectOperations extends AbstractConnector {
                                         }
                                     }
                                 } else {
+                                    if (log.isDebugEnabled()) {
+                                        log.debug("Content length is below the streaming threshold. " +
+                                                "Using single-part upload for operation: " + operationName);
+                                    }
                                     s3RequestBody = RequestBody.fromInputStream(inputStream, contentLength);
                                 }
                             } catch (IOException e) {
@@ -309,10 +340,21 @@ public class ObjectOperations extends AbstractConnector {
                             }
                         } else {
                             errorMessage = "The content of the message body should be optimized for streaming: " + operationName;
+                            log.error(errorMessage);
                             throw new InvalidConfigurationException("The content of the message body should be optimized for streaming: "
                                     + operationName);
                         }
+                    } else {
+                        errorMessage = "No valid content found in the message body for streaming: " + operationName;
+                        log.error(errorMessage);
+                        throw new InvalidConfigurationException("No valid content found in the message body for streaming: "
+                                + operationName);
                     }
+                } else {
+                    errorMessage = "No content found in the message body for streaming: " + operationName;
+                    log.error(errorMessage);
+                    throw new InvalidConfigurationException("No content found in the message body for streaming: "
+                            + operationName);
                 }
             }
             destinationFilePath = (String) ConnectorUtils.
@@ -1252,6 +1294,10 @@ public class ObjectOperations extends AbstractConnector {
                             .build()
             ).uploadId();
 
+            if (log.isDebugEnabled()) {
+                log.debug("Initiated multipart upload with uploadId: " + uploadId);
+            }
+
             List<CompletedPart> completedParts = new ArrayList<>();
             byte[] buffer = new byte[streamingPartSizeValue];
             int partNumber = 1;
@@ -1272,6 +1318,9 @@ public class ObjectOperations extends AbstractConnector {
                         .partNumber(partNumber)
                         .eTag(partResponse.eTag())
                         .build());
+                if (log.isDebugEnabled()) {
+                    log.debug("Uploaded part " + partNumber + " with ETag: " + partResponse.eTag());
+                }
                 partNumber++;
             }
 
@@ -1279,6 +1328,9 @@ public class ObjectOperations extends AbstractConnector {
             // Multipart upload requires at least one part, so abort it and
             // fall back to a zero-byte PutObject instead.
             if (completedParts.isEmpty()) {
+                if  (log.isDebugEnabled()) {
+                    log.debug("Input stream was empty, aborting multipart upload and uploading zero-byte object");
+                }
                 abortSilently(s3Client, bucketName, objectKey, uploadId, requestPayer);
                 uploadId = null; // prevent a second abort in the catch blocks
                 s3Client.putObject(
@@ -1319,6 +1371,9 @@ public class ObjectOperations extends AbstractConnector {
                         true,
                         null,
                         "Successfully uploaded empty object: " + objectKey));
+                if (log.isDebugEnabled()) {
+                    log.debug("Successfully uploaded empty object: " + objectKey);
+                }
                 return;
             }
 
@@ -1332,6 +1387,10 @@ public class ObjectOperations extends AbstractConnector {
                                     .build())
                             .requestPayer(requestPayer)
                             .build());
+
+            if (log.isDebugEnabled()) {
+                log.debug("Completed multipart upload with uploadId: " + uploadId);
+            }
 
             OMElement responseElement = S3ConnectorUtils.createOMElement("PutObjectResponse", "");
             org.wso2.carbon.connector.amazons3.pojo.PutObjectResponse uploadResponse =
@@ -1347,6 +1406,10 @@ public class ObjectOperations extends AbstractConnector {
             S3ConnectorUtils.setResultAsPayload(messageContext, new S3OperationResult(
                     operationName,
                     true, responseElement));
+            if  (log.isDebugEnabled()) {
+                log.debug("Successfully uploaded object: " + objectKey +
+                        " using multipart upload with uploadId: " + uploadId);
+            }
 
         } catch (IOException e) {
             abortSilently(s3Client, bucketName, objectKey, uploadId, requestPayer);
@@ -1372,6 +1435,9 @@ public class ObjectOperations extends AbstractConnector {
      */
     private void abortSilently(S3Client s3Client, String bucketName, String objectKey,
                                String uploadId, String requestPayer) {
+        if (log.isDebugEnabled()) {
+            log.debug("Aborting multipart upload with uploadId: " + uploadId);
+        }
         if (uploadId == null) {
             return;
         }
@@ -1382,6 +1448,9 @@ public class ObjectOperations extends AbstractConnector {
                     .uploadId(uploadId)
                     .requestPayer(requestPayer)
                     .build());
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully aborted multipart upload with uploadId: " + uploadId);
+            }
         } catch (Exception e) {
             log.warn("Failed to abort multipart upload " + uploadId + ": " + e.getMessage());
         }
@@ -1485,6 +1554,9 @@ public class ObjectOperations extends AbstractConnector {
                 .build();
         try {
             PutObjectResponse response = s3Client.putObject(request, requestBody);
+            if (log.isDebugEnabled()) {
+                log.debug("Successfully uploaded object: " + objectKey);
+            }
             OMElement responseElement = S3ConnectorUtils.createOMElement("PutObjectResponse", "");
             org.wso2.carbon.connector.amazons3.pojo.PutObjectResponse uploadResponse =
                     s3POJOHandler.castS3PutObjectResponse(response);

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
@@ -79,6 +79,7 @@ import javax.xml.stream.XMLStreamException;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
@@ -96,6 +97,11 @@ import java.util.stream.Collectors;
 public class ObjectOperations extends AbstractConnector {
     private static Log log = LogFactory.getLog(ObjectOperations.class);
     S3POJOHandler s3POJOHandler = new S3POJOHandler();
+
+    /** Files at or above this size (in bytes) use streaming multipart upload. */
+    private static final long STREAMING_MULTIPART_THRESHOLD = 100L * 1024 * 1024; // 100 MB
+    /** Each part sent to S3 during streaming multipart upload is at most this many bytes. */
+    private static final int STREAMING_PART_SIZE = 100 * 1024 * 1024; // 100 MB
 
     public final void connect(final MessageContext messageContext) throws ConnectException {
 
@@ -115,11 +121,15 @@ public class ObjectOperations extends AbstractConnector {
                 objectLockLegalHoldStatus, copySourceIfMatch, copySourceIfNoneMatch, metadataDirective,
                 taggingDirective, destinationKey, expires, copySourceIfModifiedSince, copySourceIfUnmodifiedSince,
                 objectLockRetainUntilDate, destinationFilePath, fileContent, isFileContentEncoded,
-                signatureDurationInMins, isContentAsBase64;
+                signatureDurationInMins, isContentAsBase64, enableStreaming, streamingThreshold, streamingPartSize;
         Map<String, String> metadata;
         int maxParts, partNumberMarker;
         Integer partNumber = null;
         RequestBody s3RequestBody = null;
+        boolean useStreamingMultipart = false;
+        InputStream streamInputStream = null;
+        long streamingThresholdValue = STREAMING_MULTIPART_THRESHOLD;
+        int streamingPartSizeValue = STREAMING_PART_SIZE;
         List<Part> s3PartDetails = new ArrayList<>();
         List<CompletedPart> s3CompletedParts = new ArrayList<>();
         AccessControlPolicy s3AccessControlPolicy = AccessControlPolicy.builder().build();
@@ -213,6 +223,10 @@ public class ObjectOperations extends AbstractConnector {
                     lookupTemplateParamater(messageContext, "objectLockLegalHoldStatus");
             Object maxPartsObj = ConnectorUtils.
                     lookupTemplateParamater(messageContext, "maxParts");
+            streamingThreshold = (String) ConnectorUtils.
+                    lookupTemplateParamater(messageContext, "streamingThreshold");
+            streamingPartSize = (String) ConnectorUtils.
+                    lookupTemplateParamater(messageContext, "streamingPartSize");
             maxParts = maxPartsObj != null ? Integer.valueOf((String) maxPartsObj) : 1000;
             Object partNumberMarkerObj = ConnectorUtils.
                     lookupTemplateParamater(messageContext, "partNumberMarker");
@@ -245,6 +259,61 @@ public class ObjectOperations extends AbstractConnector {
             }
             if (StringUtils.isNotEmpty(filePath)) {
                 s3RequestBody = RequestBody.fromFile(Paths.get(filePath));
+            }
+            enableStreaming = (String) ConnectorUtils.
+                    lookupTemplateParamater(messageContext, "enableStreaming");
+            if (Boolean.parseBoolean(enableStreaming) && s3RequestBody == null) {
+                org.apache.axis2.context.MessageContext axis2MsgCtx =
+                        ((org.apache.synapse.core.axis2.Axis2MessageContext) messageContext)
+                                .getAxis2MessageContext();
+                OMElement binaryElement = axis2MsgCtx.getEnvelope().getBody().getFirstElement();
+                if (binaryElement != null) {
+                    org.apache.axiom.om.OMNode firstChild = binaryElement.getFirstOMChild();
+                    if (firstChild instanceof org.apache.axiom.om.OMText) {
+                        org.apache.axiom.om.OMText omText = (org.apache.axiom.om.OMText) firstChild;
+                        if (omText.isOptimized()) {
+                            javax.activation.DataHandler dataHandler =
+                                    (javax.activation.DataHandler) omText.getDataHandler();
+                            try {
+                                InputStream inputStream = dataHandler.getInputStream();
+                                Object fileSizeObj = messageContext.getProperty("FILE_SIZE");
+                                long contentLength = fileSizeObj instanceof Long
+                                        ? (Long) fileSizeObj : -1L;
+                                if (StringUtils.isNotEmpty(streamingThreshold)) {
+                                    try {
+                                        streamingThresholdValue = Long.parseLong(streamingThreshold);
+                                    } catch (NumberFormatException e) {
+                                        errorMessage = "Invalid streaming threshold value: " + streamingThreshold;
+                                        throw new InvalidConfigurationException("Invalid streaming threshold value: "
+                                                + streamingThreshold, e);
+                                    }
+                                }
+                                if (contentLength < 0 || contentLength >= streamingThresholdValue) {
+                                    useStreamingMultipart = true;
+                                    streamInputStream = inputStream;
+                                    if (StringUtils.isNotEmpty(streamingPartSize)) {
+                                        try {
+                                            streamingPartSizeValue = Integer.parseInt(streamingPartSize);
+                                        } catch (NumberFormatException e) {
+                                            errorMessage = "Invalid streaming part size value: " + streamingPartSize;
+                                            throw new InvalidConfigurationException("Invalid streaming part size value: "
+                                                    + streamingPartSize, e);
+                                        }
+                                    }
+                                } else {
+                                    s3RequestBody = RequestBody.fromInputStream(inputStream, contentLength);
+                                }
+                            } catch (IOException e) {
+                                handleException("Failed to read input stream from message body: "
+                                        + e.getMessage(), e, messageContext);
+                            }
+                        } else {
+                            errorMessage = "The content of the message body should be optimized for streaming: " + operationName;
+                            throw new InvalidConfigurationException("The content of the message body should be optimized for streaming: "
+                                    + operationName);
+                        }
+                    }
+                }
             }
             destinationFilePath = (String) ConnectorUtils.
                     lookupTemplateParamater(messageContext, "destinationFilePath");
@@ -427,13 +496,24 @@ public class ObjectOperations extends AbstractConnector {
                     break;
                 case S3Constants.OPERATION_PUT_OBJECT:
                     errorMessage = "Error while creating the object";
-                    putObject(operationName, s3Client, acl, bucketName, cacheControl, contentDisposition,
-                            contentEncoding, contentLanguage, contentType, contentMD5, expires, grantFullControl,
-                            grantRead, grantReadACP, grantWriteACP, objectKey, metadata, serverSideEncryption,
-                            storageClass, websiteRedirectLocation, sseCustomerAlgorithm, sseCustomerKey,
-                            sseCustomerKeyMD5, ssekmsKeyId, ssekmsEncryptionContext, requestPayer, tagging,
-                            objectLockMode, objectLockRetainUntilDate, objectLockLegalHoldStatus, s3RequestBody,
-                            messageContext);
+                    if (useStreamingMultipart) {
+                        streamingMultipartUpload(operationName, s3Client, acl, bucketName, cacheControl,
+                                contentDisposition, contentEncoding, contentLanguage, contentType, contentMD5,
+                                expires, grantFullControl, grantRead, grantReadACP, grantWriteACP, objectKey,
+                                metadata, serverSideEncryption, storageClass, websiteRedirectLocation,
+                                sseCustomerAlgorithm, sseCustomerKey, sseCustomerKeyMD5, ssekmsKeyId,
+                                ssekmsEncryptionContext, requestPayer, tagging, objectLockMode,
+                                objectLockRetainUntilDate, objectLockLegalHoldStatus,
+                                streamInputStream, messageContext, streamingPartSizeValue);
+                    } else {
+                        putObject(operationName, s3Client, acl, bucketName, cacheControl, contentDisposition,
+                                contentEncoding, contentLanguage, contentType, contentMD5, expires, grantFullControl,
+                                grantRead, grantReadACP, grantWriteACP, objectKey, metadata, serverSideEncryption,
+                                storageClass, websiteRedirectLocation, sseCustomerAlgorithm, sseCustomerKey,
+                                sseCustomerKeyMD5, ssekmsKeyId, ssekmsEncryptionContext, requestPayer, tagging,
+                                objectLockMode, objectLockRetainUntilDate, objectLockLegalHoldStatus, s3RequestBody,
+                                messageContext);
+                    }
                     break;
                 case S3Constants.OPERATION_PUT_OBJECT_ACL:
                     errorMessage = "Error while creating the object ACL";
@@ -1118,6 +1198,209 @@ public class ObjectOperations extends AbstractConnector {
             S3ConnectorUtils.setResultAsPayload(messageContext, result);
             handleException("Error occurred while accessing the AWS SDK service", e, messageContext);
         }
+    }
+
+    /**
+     * Uploads an InputStream to S3 using the multipart upload API, reading the stream in
+     * {@link #STREAMING_PART_SIZE} chunks. This keeps heap usage bounded to O(STREAMING_PART_SIZE)
+     * regardless of total file size, and supports files larger than the 5 GB PutObject limit.
+     * The multipart upload is aborted automatically if any part fails.
+     * All object-level metadata parameters are forwarded to the CreateMultipartUpload request
+     * so that nothing is lost compared with a regular putObject call.
+     */
+    private void streamingMultipartUpload(String operationName, S3Client s3Client, String acl, String bucketName,
+            String cacheControl, String contentDisposition, String contentEncoding, String contentLanguage,
+            String contentType, String contentMD5, String expires, String grantFullControl, String grantRead,
+            String grantReadACP, String grantWriteACP, String objectKey, Map<String, String> metadata,
+            String serverSideEncryption, String storageClass, String websiteRedirectLocation,
+            String sseCustomerAlgorithm, String sseCustomerKey, String sseCustomerKeyMD5, String ssekmsKeyId,
+            String ssekmsEncryptionContext, String requestPayer, String tagging, String objectLockMode,
+            String objectLockRetainUntilDate, String objectLockLegalHoldStatus,
+            InputStream inputStream, MessageContext messageContext, int streamingPartSizeValue) {
+        String uploadId = null;
+        try {
+            uploadId = s3Client.createMultipartUpload(
+                    CreateMultipartUploadRequest.builder()
+                            .acl(acl)
+                            .bucket(bucketName)
+                            .cacheControl(cacheControl)
+                            .contentDisposition(contentDisposition)
+                            .contentEncoding(contentEncoding)
+                            .contentLanguage(contentLanguage)
+                            .contentType(contentType)
+                            .expires(expires != null ? Instant.parse(expires) : null)
+                            .grantFullControl(grantFullControl)
+                            .grantRead(grantRead)
+                            .grantReadACP(grantReadACP)
+                            .grantWriteACP(grantWriteACP)
+                            .key(objectKey)
+                            .metadata(metadata)
+                            .serverSideEncryption(serverSideEncryption)
+                            .storageClass(storageClass)
+                            .websiteRedirectLocation(websiteRedirectLocation)
+                            .sseCustomerAlgorithm(sseCustomerAlgorithm)
+                            .sseCustomerKey(sseCustomerKey)
+                            .sseCustomerKeyMD5(sseCustomerKeyMD5)
+                            .ssekmsKeyId(ssekmsKeyId)
+                            .ssekmsEncryptionContext(ssekmsEncryptionContext)
+                            .requestPayer(requestPayer)
+                            .tagging(tagging)
+                            .objectLockMode(objectLockMode)
+                            .objectLockRetainUntilDate(objectLockRetainUntilDate != null ?
+                                    Instant.parse(objectLockRetainUntilDate) : null)
+                            .objectLockLegalHoldStatus(objectLockLegalHoldStatus)
+                            .build()
+            ).uploadId();
+
+            List<CompletedPart> completedParts = new ArrayList<>();
+            byte[] buffer = new byte[streamingPartSizeValue];
+            int partNumber = 1;
+            int bytesRead;
+
+            while ((bytesRead = readFully(inputStream, buffer, streamingPartSizeValue)) > 0) {
+                UploadPartResponse partResponse = s3Client.uploadPart(
+                        UploadPartRequest.builder()
+                                .bucket(bucketName)
+                                .key(objectKey)
+                                .uploadId(uploadId)
+                                .partNumber(partNumber)
+                                .requestPayer(requestPayer)
+                                .build(),
+                        RequestBody.fromInputStream(
+                                new java.io.ByteArrayInputStream(buffer, 0, bytesRead), bytesRead));
+                completedParts.add(CompletedPart.builder()
+                        .partNumber(partNumber)
+                        .eTag(partResponse.eTag())
+                        .build());
+                partNumber++;
+            }
+
+            // If the input stream was empty, no parts were uploaded.
+            // Multipart upload requires at least one part, so abort it and
+            // fall back to a zero-byte PutObject instead.
+            if (completedParts.isEmpty()) {
+                abortSilently(s3Client, bucketName, objectKey, uploadId, requestPayer);
+                uploadId = null; // prevent a second abort in the catch blocks
+                s3Client.putObject(
+                        PutObjectRequest.builder()
+                                .acl(acl)
+                                .bucket(bucketName)
+                                .cacheControl(cacheControl)
+                                .contentDisposition(contentDisposition)
+                                .contentEncoding(contentEncoding)
+                                .contentLanguage(contentLanguage)
+                                .contentMD5(contentMD5)
+                                .contentType(contentType)
+                                .expires(expires != null ? Instant.parse(expires) : null)
+                                .grantFullControl(grantFullControl)
+                                .grantRead(grantRead)
+                                .grantReadACP(grantReadACP)
+                                .grantWriteACP(grantWriteACP)
+                                .key(objectKey)
+                                .metadata(metadata)
+                                .serverSideEncryption(serverSideEncryption)
+                                .storageClass(storageClass)
+                                .websiteRedirectLocation(websiteRedirectLocation)
+                                .sseCustomerAlgorithm(sseCustomerAlgorithm)
+                                .sseCustomerKey(sseCustomerKey)
+                                .sseCustomerKeyMD5(sseCustomerKeyMD5)
+                                .ssekmsKeyId(ssekmsKeyId)
+                                .ssekmsEncryptionContext(ssekmsEncryptionContext)
+                                .requestPayer(requestPayer)
+                                .tagging(tagging)
+                                .objectLockMode(objectLockMode)
+                                .objectLockRetainUntilDate(objectLockRetainUntilDate != null ?
+                                        Instant.parse(objectLockRetainUntilDate) : null)
+                                .objectLockLegalHoldStatus(objectLockLegalHoldStatus)
+                                .build(),
+                        RequestBody.empty());
+                S3ConnectorUtils.setResultAsPayload(messageContext, new S3OperationResult(
+                        operationName,
+                        true,
+                        null,
+                        "Successfully uploaded empty object: " + objectKey));
+                return;
+            }
+
+            CompleteMultipartUploadResponse completeMultipartUploadResponse =
+                    s3Client.completeMultipartUpload(CompleteMultipartUploadRequest.builder()
+                            .bucket(bucketName)
+                            .key(objectKey)
+                            .uploadId(uploadId)
+                            .multipartUpload(CompletedMultipartUpload.builder()
+                                    .parts(completedParts)
+                                    .build())
+                            .requestPayer(requestPayer)
+                            .build());
+
+            OMElement responseElement = S3ConnectorUtils.createOMElement("PutObjectResponse", "");
+            org.wso2.carbon.connector.amazons3.pojo.PutObjectResponse uploadResponse =
+                    s3POJOHandler.castS3CompleteMultipartUploadResponseToPutObjectResponse(
+                            completeMultipartUploadResponse);
+            String responseString = s3POJOHandler.getObjectAsXml(uploadResponse,
+                    org.wso2.carbon.connector.amazons3.pojo.PutObjectResponse.class);
+            try {
+                responseElement = AXIOMUtil.stringToOM(responseString);
+            } catch (XMLStreamException e) {
+                handleException("Unable to process the response: " + e.getMessage(), e, messageContext);
+            }
+            S3ConnectorUtils.setResultAsPayload(messageContext, new S3OperationResult(
+                    operationName,
+                    true, responseElement));
+
+        } catch (IOException e) {
+            abortSilently(s3Client, bucketName, objectKey, uploadId, requestPayer);
+            handleException("Failed to stream content for multipart upload: " + e.getMessage(),
+                    e, messageContext);
+        } catch (S3Exception e) {
+            abortSilently(s3Client, bucketName, objectKey, uploadId, requestPayer);
+            S3ConnectorUtils.setResultAsPayload(messageContext,
+                    S3ConnectorUtils.getFailureResult(e.awsErrorDetails().errorMessage(),
+                            operationName, Error.BAD_REQUEST));
+        } catch (AwsServiceException | SdkClientException e) {
+            abortSilently(s3Client, bucketName, objectKey, uploadId, requestPayer);
+            S3ConnectorUtils.setResultAsPayload(messageContext, new S3OperationResult(
+                    operationName, false, Error.CONNECTION_ERROR,
+                    "Error occurred while accessing the AWS SDK service: " + e.getMessage()));
+            handleException("Error occurred while accessing the AWS SDK service", e, messageContext);
+        }
+    }
+
+    /**
+     * Aborts a multipart upload, suppressing any exception so it can be used safely inside
+     * error-handling paths without masking the original failure.
+     */
+    private void abortSilently(S3Client s3Client, String bucketName, String objectKey,
+                               String uploadId, String requestPayer) {
+        if (uploadId == null) {
+            return;
+        }
+        try {
+            s3Client.abortMultipartUpload(AbortMultipartUploadRequest.builder()
+                    .bucket(bucketName)
+                    .key(objectKey)
+                    .uploadId(uploadId)
+                    .requestPayer(requestPayer)
+                    .build());
+        } catch (Exception e) {
+            log.warn("Failed to abort multipart upload " + uploadId + ": " + e.getMessage());
+        }
+    }
+
+    /**
+     * Fills {@code buf[0..len-1]} from {@code in}, looping until exactly {@code len} bytes have
+     * been read or the stream is exhausted. Returns the number of bytes actually read.
+     */
+    private static int readFully(InputStream in, byte[] buf, int len) throws IOException {
+        int total = 0;
+        while (total < len) {
+            int n = in.read(buf, total, len - total);
+            if (n == -1) {
+                break;
+            }
+            total += n;
+        }
+        return total;
     }
 
     private void multipartUpload(String operationName, S3Client s3Client, String bucketName, String objectKey,

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/ObjectOperations.java
@@ -102,6 +102,17 @@ public class ObjectOperations extends AbstractConnector {
     private static final long STREAMING_MULTIPART_THRESHOLD = 100L * 1024 * 1024; // 100 MB
     /** Each part sent to S3 during streaming multipart upload is at most this many bytes. */
     private static final int STREAMING_PART_SIZE = 100 * 1024 * 1024; // 100 MB
+    /**
+     * S3 requires every part except the last to be at least 5 MB.
+     * Using this as the minimum for all parts keeps the configuration valid.
+     */
+    private static final int MIN_STREAMING_PART_SIZE = 5 * 1024 * 1024; // 5 MB
+    /**
+     * Hard upper bound for the per-part buffer to prevent OutOfMemoryError.
+     * 5 GB is the S3 maximum single-part size; Integer.MAX_VALUE (~2 GB) is used
+     * here so the value fits safely in a signed 32-bit int and leaves headroom for the JVM.
+     */
+    private static final int MAX_STREAMING_PART_SIZE = Integer.MAX_VALUE; // ~2 GB
 
     public final void connect(final MessageContext messageContext) throws ConnectException {
 
@@ -319,6 +330,14 @@ public class ObjectOperations extends AbstractConnector {
                                     if (StringUtils.isNotEmpty(streamingPartSize)) {
                                         try {
                                             streamingPartSizeValue = Integer.parseInt(streamingPartSize);
+                                            if (streamingPartSizeValue < MIN_STREAMING_PART_SIZE
+                                                    || streamingPartSizeValue > MAX_STREAMING_PART_SIZE) {
+                                                errorMessage = "Streaming part size must be between "
+                                                        + MIN_STREAMING_PART_SIZE + " bytes (5 MB) and "
+                                                        + MAX_STREAMING_PART_SIZE + " bytes (~2 GB), but was: "
+                                                        + streamingPartSizeValue;
+                                                throw new InvalidConfigurationException(errorMessage);
+                                            }
                                             if (log.isDebugEnabled()) {
                                                 log.debug("Using custom streaming part size value: " +
                                                         streamingPartSizeValue + " for operation: " + operationName);

--- a/src/main/resources/objects/putObject.xml
+++ b/src/main/resources/objects/putObject.xml
@@ -21,6 +21,10 @@
     <parameter name="filePath" description="The path of the source file to be uploaded."/>
     <parameter name="fileContent" description="Content of the file."/>
     <parameter name="isContentBase64Encoded" description="Whether the file content is base64 encoded."/>
+    <parameter name="enableStreaming"
+               description="When true, reads the upload content directly from the binary payload in the message body
+               as a streaming InputStream, avoiding full in-memory buffering. Use this for large file passthrough transfers, e.g. SFTP to S3, to prevent
+               OutOfMemory errors."/>
     <parameter name="acl"
                description="Canned ACL which defines the set of AWS accounts or groups are granted access and the type of access."/>
     <parameter name="cacheControl" description="Specifies caching behavior along the request/reply chain."/>
@@ -61,6 +65,8 @@
                description="Specifies the date and time when you want the Object Lock to expire."/>
     <parameter name="objectLockLegalHoldStatus"
                description="Specifies whether you want to apply a Legal Hold to the uploaded object."/>
+    <parameter name="streamingThreshold" description="The threshold in bytes for when to switch to multipart Upload. If the content size exceeds this threshold, the connector will automatically switch to multipart Upload. Requires enableStreaming=true."/>
+    <parameter name="streamingPartSize" description="The part size in bytes to use when performing a multipart Upload. Must be at least 5 MB. Requires enableStreaming=true."/>
     <sequence>
         <property name="operationName" value="putObject"/>
         <class name="org.wso2.carbon.connector.amazons3.operations.ObjectOperations"/>

--- a/src/main/resources/uischema/putObject.json
+++ b/src/main/resources/uischema/putObject.json
@@ -200,7 +200,7 @@
                     "inputType": "stringOrExpression",
                     "defaultValue": "",
                     "required": "false",
-                    "helpTip": "The part size in bytes to use when performing multipart upload for streaming upload. Minimum value should be 5MB. Default is 100MB. This requires the file content to be provided in the message body as binary and the file path / file Content attribute to be left empty."
+                    "helpTip": "The part size in bytes to use when performing multipart upload for streaming upload. Minimum value should be 5MB. Default is 100MB. This requires the file content to be provided in the message body as binary and the filePath / fileContent attribute to be left empty."
                   }
                 },
                 {

--- a/src/main/resources/uischema/putObject.json
+++ b/src/main/resources/uischema/putObject.json
@@ -173,6 +173,39 @@
                 {
                   "type": "attribute",
                   "value": {
+                    "name": "enableStreaming",
+                    "displayName": "Streaming Enabled",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "Whether to enable streaming upload. This requires the file content to be provided in the message body as binary and the filePath / fileContent attribute to be left empty."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "streamingThreshold",
+                    "displayName": "Streaming Threshold (Bytes)",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The threshold size in bytes for enabling streaming upload. If the file size is larger than the specified threshold, the file will be uploaded using multipart upload. Default is 100MB. This requires the file content to be provided in the message body as binary and the filePath / fileContent attribute to be left empty."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "streamingPartSize",
+                    "displayName": "Streaming Part Size (Bytes)",
+                    "inputType": "stringOrExpression",
+                    "defaultValue": "",
+                    "required": "false",
+                    "helpTip": "The part size in bytes to use when performing multipart upload for streaming upload. Minimum value should be 5MB. Default is 100MB. This requires the file content to be provided in the message body as binary and the file path / file Content attribute to be left empty."
+                  }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
                     "name": "expires",
                     "displayName": "Expires",
                     "inputType": "stringOrExpression",


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.


Adds streaming upload support for the putObject operation so large/binary payloads can be uploaded from the message body (optimized binary) and automatically switch to multipart upload based on size thresholds.

<img width="803" height="316" alt="Screenshot 2026-03-26 at 21 07 00" src="https://github.com/user-attachments/assets/4ef17024-b129-438f-be19-b7c95511b861" />


Resolves https://github.com/wso2/product-micro-integrator/issues/4753