### PR TITLE
Add option to use path style addressing for S3 objects when defining a custom host

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
@@ -62,6 +62,7 @@ public class S3ConnectionHandler implements Connection {
         String awsAccessKeyId = this.connectionConfig.getAwsAccessKeyId();
         String awsSecretAccessKey = this.connectionConfig.getAwsSecretAccessKey();
         String host = this.connectionConfig.getHost();
+        boolean forcePathStyle = this.connectionConfig.isForcePathStyle();
         String roleArn = this.connectionConfig.getRoleArn();
         String roleSessionName = this.connectionConfig.getRoleSessionName();
         S3ClientBuilder s3ClientBuilder = S3Client.builder();
@@ -92,6 +93,9 @@ public class S3ConnectionHandler implements Connection {
 
 		if (StringUtils.isNotEmpty(host)) {
 			s3ClientBuilder.endpointOverride(URI.create(host));
+			if (forcePathStyle) {
+				s3ClientBuilder.forcePathStyle(true);
+			}
 		}
 
 		return s3ClientBuilder.region(Region.of(region))

--- a/src/main/java/org/wso2/carbon/connector/amazons3/constants/S3Constants.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/constants/S3Constants.java
@@ -121,4 +121,5 @@ public class S3Constants {
 
 
     public static final String UTF_8 = "UTF-8";
+    public static final String FORCE_PATH_STYLE = "forcePathStyle";
 }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
@@ -64,6 +64,7 @@ public class S3Config extends AbstractConnector implements ManagedLifecycle {
         String awsSecretAccessKey = (String) ConnectorUtils.
                 lookupTemplateParamater(msgContext, S3Constants.AWS_SECRET_ACCESS_KEY);
         String host = (String) ConnectorUtils.lookupTemplateParamater(msgContext, S3Constants.HOST);
+        String forcePathStyleStr = (String) ConnectorUtils.lookupTemplateParamater(msgContext, S3Constants.FORCE_PATH_STYLE);
         String roleArn = (String) ConnectorUtils.lookupTemplateParamater(msgContext, S3Constants.ROLE_ARN);
         String roleSessionName = (String) ConnectorUtils.lookupTemplateParamater(msgContext, S3Constants.ROLE_SESSION_NAME);
 
@@ -73,6 +74,7 @@ public class S3Config extends AbstractConnector implements ManagedLifecycle {
         connectionConfig.setAwsAccessKeyId(awsAccessKeyId);
         connectionConfig.setAwsSecretAccessKey(awsSecretAccessKey);
         connectionConfig.setHost(host);
+        connectionConfig.setForcePathStyle(Boolean.parseBoolean(forcePathStyleStr));
         connectionConfig.setRoleArn(roleArn);
         connectionConfig.setRoleSessionName(roleSessionName);
         return connectionConfig;

--- a/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ConnectionConfiguration.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/pojo/ConnectionConfiguration.java
@@ -33,6 +33,7 @@ public class ConnectionConfiguration {
     private String awsSecretAccessKey;
 
     private String host;
+    private boolean forcePathStyle;
 
     private String roleArn;
 
@@ -101,5 +102,13 @@ public class ConnectionConfiguration {
 
     public void setRoleSessionName(String roleSessionName) {
         this.roleSessionName = roleSessionName;
+    }
+
+    public boolean isForcePathStyle() {
+        return forcePathStyle;
+    }
+
+    public void setForcePathStyle(boolean forcePathStyle) {
+        this.forcePathStyle = forcePathStyle;
     }
 }

--- a/src/main/resources/config/init.xml
+++ b/src/main/resources/config/init.xml
@@ -21,6 +21,7 @@
     <parameter name="awsAccessKeyId" description="AWS access key ID"/>
     <parameter name="awsSecretAccessKey" description="AWS secret key"/>
     <parameter name="host" description="AWS SDK host"/>
+    <parameter name="forcePathStyle" description="Whether to force path style access for all requests"/>
     <parameter name="roleArn" description="AWS role ARN"/>
     <parameter name="roleSessionName" description="AWS role session name"/>
     <sequence>

--- a/src/main/resources/uischema/connection.json
+++ b/src/main/resources/uischema/connection.json
@@ -69,6 +69,17 @@
                     "required": "false",
                     "helpTip": "For path-style requests, the value is s3.amazonaws.com. For virtual-style requests, the value is BucketName.s3.amazonaws.com."
                   }
+                },
+                {
+                  "type": "attribute",
+                  "value": {
+                    "name": "forcePathStyle",
+                    "displayName": "Force Path Style",
+                    "inputType": "booleanOrExpression",
+                    "defaultValue": "false",
+                    "required": "false",
+                    "helpTip": "Whether to force path style addressing for S3 objects when defining a custom host."
+                  }
                 }
               ]
             }


### PR DESCRIPTION
## Purpose

Add option to use path style addressing for S3 objects when defining a custom host

```xml
<amazons3.init>
  <connectionType>AMAZONS3</connectionType>
  <awsAccessKeyId>xx</awsAccessKeyId>
  <awsSecretAccessKey>xx</awsSecretAccessKey>
  <region>garage</region>
  <host>http://localhost:3900</host>
  <forcePathStyle>true</forcePathStyle>
  <name>GarageS3</name>
</amazons3.init>
```

Fixes: https://github.com/wso2/product-integrator-mi/issues/4897