### PR TITLE
Update S3ConnectionHandler to use local entry undeploy observer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <automation.framework.version>4.4.3</automation.framework.version>
         <emma.version>2.1.5320</emma.version>
         <synapse.version>2.1.7-wso2v95</synapse.version>
-        <carbon.mediation.version>4.7.52</carbon.mediation.version>
+        <carbon.mediation.version>4.7.183</carbon.mediation.version>
         <json.version>3.0.0.wso2v1</json.version>
         <org.testng.version>6.1.1</org.testng.version>
         <jets3t.version>0.9.4</jets3t.version>

--- a/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
@@ -4,7 +4,9 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.connector.amazons3.pojo.ConnectionConfiguration;
+import org.wso2.carbon.connector.core.ConnectException;
 import org.wso2.carbon.connector.core.connection.Connection;
+import org.wso2.carbon.connector.core.connection.ConnectionConfig;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -119,5 +121,19 @@ public class S3ConnectionHandler implements Connection {
             s3PresignerBuilder.endpointOverride(URI.create(host));
         }
         return s3PresignerBuilder.region(Region.of(region)).build();
+    }
+
+    @Override
+    public void connect(ConnectionConfig connectionConfig) throws ConnectException {
+        // No implementation needed as the connection is established when the S3Client is created
+    }
+
+    @Override
+    public void close() throws ConnectException {
+        if (s3Client != null) {
+            log.debug("Closing the S3 client");
+            s3Client.close();
+            s3Client = null;
+        }
     }
 }

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
@@ -37,7 +37,11 @@ public class S3Config extends AbstractConnector implements ManagedLifecycle {
             ConnectionHandler handler = ConnectionHandler.getConnectionHandler();
             if (!handler.checkIfConnectionExists(connectorName, connectionName)) {
                 S3ConnectionHandler s3ConnectionHandler = new S3ConnectionHandler(configuration);
-                handler.createConnection(S3Constants.CONNECTOR_NAME, connectionName, s3ConnectionHandler);
+                try {
+                    handler.createConnection(S3Constants.CONNECTOR_NAME, connectionName, s3ConnectionHandler, messageContext);
+                } catch (NoSuchMethodError e) {
+                    handler.createConnection(S3Constants.CONNECTOR_NAME, connectionName, s3ConnectionHandler);
+                }
             } else {
                 S3ConnectionHandler connectionHandler = (S3ConnectionHandler) handler
                         .getConnection(connectorName, connectionName);


### PR DESCRIPTION
## Purpose

Update S3ConnectionHandler to use local entry undeploy observer

Fixes: https://github.com/wso2/product-integrator-mi/issues/4959