### PR TITLE
[3.x] Update S3ConnectionHandler to use local entry undeploy observer

### DIFF
--- a/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/connection/S3ConnectionHandler.java
@@ -54,7 +54,13 @@ public class S3ConnectionHandler implements Connection {
     }
 
     @Override
-    public void close() {}
+    public void close() {
+        if (s3Client != null) {
+            log.debug("Closing the S3 client");
+            s3Client.close();
+            s3Client = null;
+        }
+    }
 
     private S3Client createS3Client() {
 

--- a/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
+++ b/src/main/java/org/wso2/carbon/connector/amazons3/operations/S3Config.java
@@ -37,7 +37,7 @@ public class S3Config extends AbstractConnector implements ManagedLifecycle {
             ConnectionHandler handler = ConnectionHandler.getConnectionHandler();
             if (!handler.checkIfConnectionExists(connectorName, connectionName)) {
                 S3ConnectionHandler s3ConnectionHandler = new S3ConnectionHandler(configuration);
-                handler.createConnection(S3Constants.CONNECTOR_NAME, connectionName, s3ConnectionHandler);
+                handler.createConnection(S3Constants.CONNECTOR_NAME, connectionName, s3ConnectionHandler, messageContext);
             } else {
                 S3ConnectionHandler connectionHandler = (S3ConnectionHandler) handler
                         .getConnection(connectorName, connectionName);


### PR DESCRIPTION
## Purpose

Update S3ConnectionHandler to use local entry undeploy observer

Fixes: https://github.com/wso2/product-integrator-mi/issues/4959